### PR TITLE
Fix connection reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_yaml",
+ "socket2 0.6.2",
  "tokio",
  "tun-rs",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rand = "0.10"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
+socket2 = "0.6"
 tokio = { version = "1", features = ["full"] }
 tun-rs = { version = "2.8", features = ["async"] }
 url = "2"

--- a/src/gateway/nat.rs
+++ b/src/gateway/nat.rs
@@ -1,18 +1,33 @@
 use bimap::BiMap;
 use std::{
-    io::Error,
-    net::{self, Ipv4Addr},
-    sync::Arc,
+    io::{Error, ErrorKind},
+    net::Ipv4Addr,
+    sync::{
+        Arc,
+        atomic::{AtomicU16, Ordering},
+    },
     time::Duration,
 };
 use tokio::sync::{RwLock, mpsc::UnboundedSender};
 
 use moka::future::Cache;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SessionKey {
+    pub src_addr: Ipv4Addr,
+    pub dst_addr: Ipv4Addr,
+    pub src_port: u16,
+    pub dst_port: u16,
+}
+
+const EPHEMERAL_PORT_START: u16 = 49152;
+const EPHEMERAL_PORT_END: u16 = 65535;
+const EPHEMERAL_PORT_RANGE: u16 = EPHEMERAL_PORT_END - EPHEMERAL_PORT_START + 1;
+
 pub struct Nat {
-    nat_type: Type,
-    cache: Cache<u32, Arc<Session>>,
-    mapping: Arc<RwLock<BiMap<u32, u16>>>,
+    cache: Cache<SessionKey, Arc<Session>>,
+    mapping: Arc<RwLock<BiMap<SessionKey, u16>>>,
+    port_counter: AtomicU16,
 }
 
 pub enum Type {
@@ -32,17 +47,17 @@ pub struct Session {
 impl Nat {
     pub fn new(nat_type: Type, tx: Option<UnboundedSender<u16>>) -> Self {
         let ttl = match nat_type {
-            Type::Tcp => Duration::from_secs(60),
-            Type::Udp => Duration::from_secs(20),
+            Type::Tcp => Duration::from_secs(300),
+            Type::Udp => Duration::from_secs(60),
         };
 
         let mapping = Arc::new(RwLock::new(BiMap::new()));
         let cache = Self::new_cache(ttl, mapping.clone(), tx);
 
         Self {
-            nat_type,
             cache,
             mapping,
+            port_counter: AtomicU16::new(0),
         }
     }
 
@@ -53,26 +68,50 @@ impl Nat {
         dst_addr: Ipv4Addr,
         dst_port: u16,
     ) -> Result<Session, Error> {
-        let addr_key = u32::from_be_bytes(src_addr.octets()) + src_port as u32;
+        let addr_key = SessionKey {
+            src_addr,
+            dst_addr,
+            src_port,
+            dst_port,
+        };
 
         if let Some(session) = self.cache.get(&addr_key).await {
             return Ok(*session);
         }
 
         let nat_port = {
-            let mapping = self.mapping.read().await;
+            let mut mapping = self.mapping.write().await;
 
             if let Some(&nat_port) = mapping.get_by_left(&addr_key) {
-                return Ok(Session {
+                let session = Arc::new(Session {
                     src_addr,
                     dst_addr,
                     src_port,
                     dst_port,
                     nat_port,
                 });
+                self.cache.insert(addr_key, session.clone()).await;
+                return Ok(*session);
             }
 
-            self.get_available_port()?
+            let mut assigned_port = 0;
+            for _ in 0..EPHEMERAL_PORT_RANGE {
+                let port = self.next_ephemeral_port();
+                if !mapping.contains_right(&port) {
+                    assigned_port = port;
+                    break;
+                }
+            }
+
+            if assigned_port == 0 {
+                return Err(Error::new(
+                    ErrorKind::AddrInUse,
+                    "No available NAT port: ephemeral range exhausted",
+                ));
+            }
+
+            mapping.insert(addr_key, assigned_port);
+            assigned_port
         };
 
         let session = Arc::new(Session {
@@ -85,18 +124,23 @@ impl Nat {
 
         self.cache.insert(addr_key, session.clone()).await;
 
-        {
-            let mut mapping = self.mapping.write().await;
-            mapping.insert(addr_key, nat_port);
-        }
-
         Ok(*session)
     }
 
     pub async fn find(&self, nat_port: u16) -> Option<Session> {
-        if let Some(addr_key) = self.get_addr_key_by_port_fast(&nat_port).await
-            && let Some(session) = self.cache.get(&addr_key).await
-        {
+        if let Some(addr_key) = self.get_addr_key_by_port_fast(&nat_port).await {
+            if let Some(session) = self.cache.get(&addr_key).await {
+                return Some(*session);
+            }
+
+            let session = Arc::new(Session {
+                src_addr: addr_key.src_addr,
+                dst_addr: addr_key.dst_addr,
+                src_port: addr_key.src_port,
+                dst_port: addr_key.dst_port,
+                nat_port,
+            });
+            self.cache.insert(addr_key, session.clone()).await;
             return Some(*session);
         }
 
@@ -121,44 +165,36 @@ impl Nat {
 
     fn new_cache(
         ttl: Duration,
-        mapping: Arc<RwLock<BiMap<u32, u16>>>,
+        mapping: Arc<RwLock<BiMap<SessionKey, u16>>>,
         tx: Option<UnboundedSender<u16>>,
-    ) -> Cache<u32, Arc<Session>> {
+    ) -> Cache<SessionKey, Arc<Session>> {
         Cache::builder()
-            .max_capacity(5000)
+            .max_capacity(10000)
             .time_to_idle(ttl)
-            .eviction_listener(move |addr_key: Arc<u32>, session: Arc<Session>, _cause| {
-                let mapping = mapping.clone();
-                let tx = tx.clone();
-                tokio::task::spawn(async move {
-                    let mut mapping_guard = mapping.write().await;
-                    let _ = mapping_guard.remove_by_left(&*addr_key);
-                    if let Some(ref tx) = tx {
-                        let _ = tx.send(session.nat_port);
-                    }
-                });
-            })
+            .eviction_listener(
+                move |addr_key: Arc<SessionKey>, session: Arc<Session>, _cause| {
+                    let mapping = mapping.clone();
+                    let tx = tx.clone();
+                    tokio::task::spawn(async move {
+                        let mut mapping_guard = mapping.write().await;
+                        let _ = mapping_guard.remove_by_left(&*addr_key);
+                        if let Some(ref tx) = tx {
+                            let _ = tx.send(session.nat_port);
+                        }
+                    });
+                },
+            )
             .build()
     }
 
-    async fn get_addr_key_by_port_fast(&self, nat_port: &u16) -> Option<u32> {
+    async fn get_addr_key_by_port_fast(&self, nat_port: &u16) -> Option<SessionKey> {
         let mapping = self.mapping.read().await;
         mapping.get_by_right(nat_port).copied()
     }
 
-    fn get_available_port(&self) -> Result<u16, Error> {
-        match self.nat_type {
-            Type::Tcp => {
-                let listener = net::TcpListener::bind("127.0.0.1:0")?;
-                let addr = listener.local_addr()?;
-                Ok(addr.port())
-            }
-            Type::Udp => {
-                let socket = net::UdpSocket::bind("127.0.0.1:0")?;
-                let addr = socket.local_addr()?;
-                Ok(addr.port())
-            }
-        }
+    fn next_ephemeral_port(&self) -> u16 {
+        let offset = self.port_counter.fetch_add(1, Ordering::Relaxed) % EPHEMERAL_PORT_RANGE;
+        EPHEMERAL_PORT_START + offset
     }
 }
 

--- a/src/gateway/relay_tcp.rs
+++ b/src/gateway/relay_tcp.rs
@@ -1,19 +1,18 @@
 use std::{
-    io::Error,
     net::SocketAddr,
     pin::Pin,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     task::{Context, Poll},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
 
 use anyhow::{Context as _, Result};
 use log::debug;
 use tokio::{
-    io::{AsyncRead, AsyncWrite, copy_bidirectional},
+    io::{AsyncRead, AsyncWrite, ReadBuf, copy_bidirectional},
     net::{TcpListener, TcpStream},
     time::timeout,
 };
@@ -27,27 +26,38 @@ use super::{
 };
 
 const PROXY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+const IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+const WATCHDOG_INTERVAL: Duration = Duration::from_secs(15);
 
 pub(crate) struct TcpRelay {
     runtime: ArcRuntime,
-    relay_addr: String,
+    relay_listener: Mutex<Option<std::net::TcpListener>>,
     nat: Arc<Nat>,
 }
 
 impl TcpRelay {
-    pub fn new(runtime: ArcRuntime, relay_addr: String, nat: Arc<Nat>) -> Self {
+    pub fn new(runtime: ArcRuntime, relay_listener: std::net::TcpListener, nat: Arc<Nat>) -> Self {
         Self {
             runtime,
-            relay_addr,
+            relay_listener: Mutex::new(Some(relay_listener)),
             nat,
         }
     }
 
     pub async fn serve(&self) -> Result<()> {
-        let server = TcpListener::bind(&self.relay_addr)
-            .await
-            .context("Failed to bind relay server")?;
+        let listener = self
+            .relay_listener
+            .lock()
+            .unwrap()
+            .take()
+            .context("Relay listener already consumed")?;
+
+        listener
+            .set_nonblocking(true)
+            .context("Failed to set relay listener to non-blocking")?;
+
+        let server = TcpListener::from_std(listener)
+            .context("Failed to convert relay listener to tokio TcpListener")?;
 
         let nat = self.nat.clone();
         let runtime = self.runtime.clone();
@@ -58,7 +68,9 @@ impl TcpRelay {
                 let runtime = runtime.clone();
 
                 tokio::spawn(async move {
-                    let _ = handle_connection(stream, remote_addr, nat, runtime).await;
+                    if let Err(e) = handle_connection(stream, remote_addr, nat, runtime).await {
+                        debug!("TCP connection failed for {}: {:#}", remote_addr, e);
+                    }
                 });
             }
         });
@@ -108,20 +120,110 @@ async fn copy_with_idle_timeout(
     proxy_name: &str,
     target_addr: &str,
 ) -> Result<()> {
-    let tracker = Arc::new(SharedIdleTracker::new());
+    let keepalive = socket2::TcpKeepalive::new()
+        .with_time(Duration::from_secs(60))
+        .with_interval(Duration::from_secs(10));
 
-    let mut timeout_client = IdleTimeoutStream::new(client, tracker.clone(), IDLE_TIMEOUT);
-    let mut timeout_proxy = IdleTimeoutStream::new(proxy, tracker, IDLE_TIMEOUT);
+    let _ = socket2::SockRef::from(&client).set_tcp_keepalive(&keepalive);
+    let _ = socket2::SockRef::from(&proxy).set_tcp_keepalive(&keepalive);
 
-    match copy_bidirectional(&mut timeout_client, &mut timeout_proxy).await {
-        Ok((up, down)) => {
-            stats::update_metrics(runtime, Protocol::Tcp, proxy_name, target_addr, up, down);
-            Ok(())
+    let last_activity = Arc::new(AtomicU64::new(now_millis()));
+    let mut tracked_client = ActivityTracker::new(client, last_activity.clone());
+    let mut tracked_proxy = ActivityTracker::new(proxy, last_activity.clone());
+
+    tokio::select! {
+        result = copy_bidirectional(&mut tracked_client, &mut tracked_proxy) => {
+            match result {
+                Ok((up, down)) => {
+                    stats::update_metrics(runtime, Protocol::Tcp, proxy_name, target_addr, up, down);
+                }
+                Err(e) => {
+                    debug!("TCP relay error for {}: {}", target_addr, e);
+                }
+            }
         }
-        Err(e) => {
-            debug!("TCP relay error: {}", e);
-            Ok(())
+        _ = idle_watchdog(&last_activity) => {
+            debug!("TCP relay idle timeout for {} after {:?}", target_addr, IDLE_TIMEOUT);
         }
+    }
+
+    Ok(())
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+async fn idle_watchdog(last_activity: &AtomicU64) {
+    let timeout_ms = IDLE_TIMEOUT.as_millis() as u64;
+    loop {
+        tokio::time::sleep(WATCHDOG_INTERVAL).await;
+        let elapsed = now_millis().saturating_sub(last_activity.load(Ordering::Relaxed));
+        if elapsed >= timeout_ms {
+            return;
+        }
+    }
+}
+
+struct ActivityTracker<T> {
+    inner: T,
+    last_activity: Arc<AtomicU64>,
+}
+
+impl<T> ActivityTracker<T> {
+    fn new(inner: T, last_activity: Arc<AtomicU64>) -> Self {
+        Self {
+            inner,
+            last_activity,
+        }
+    }
+
+    fn touch(&self) {
+        self.last_activity.store(now_millis(), Ordering::Relaxed);
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for ActivityTracker<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let poll = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = &poll
+            && buf.filled().len() > before
+        {
+            self.touch();
+        }
+        poll
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for ActivityTracker<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let poll = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = &poll
+            && *n > 0
+        {
+            self.touch();
+        }
+        poll
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 }
 
@@ -138,141 +240,4 @@ async fn find_session_target(
     common::find_target(runtime.clone(), session)
         .await
         .ok_or_else(|| anyhow::anyhow!("No target found for session"))
-}
-
-struct SharedIdleTracker {
-    last_activity: Arc<AtomicU64>,
-}
-
-impl SharedIdleTracker {
-    fn new() -> Self {
-        let now_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
-
-        Self {
-            last_activity: Arc::new(AtomicU64::new(now_millis)),
-        }
-    }
-
-    fn update_activity(&self) {
-        let now_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
-        self.last_activity.store(now_millis, Ordering::Relaxed);
-    }
-
-    fn elapsed(&self) -> Duration {
-        let last_millis = self.last_activity.load(Ordering::Relaxed);
-        let now_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
-        Duration::from_millis(now_millis.saturating_sub(last_millis))
-    }
-
-    fn is_idle(&self, timeout: Duration) -> bool {
-        self.elapsed() > timeout
-    }
-}
-
-struct IdleTimeoutStream<T> {
-    inner: T,
-    tracker: Arc<SharedIdleTracker>,
-    timeout: Duration,
-}
-
-impl<T> IdleTimeoutStream<T> {
-    fn new(inner: T, tracker: Arc<SharedIdleTracker>, timeout: Duration) -> Self {
-        Self {
-            inner,
-            tracker,
-            timeout,
-        }
-    }
-
-    fn update_activity(&self) {
-        self.tracker.update_activity();
-    }
-
-    fn check_idle(&self) -> tokio::io::Result<()> {
-        if self.tracker.is_idle(self.timeout) {
-            return Err(tokio::io::Error::new(
-                tokio::io::ErrorKind::TimedOut,
-                "idle timeout - no activity on either side",
-            ));
-        }
-        Ok(())
-    }
-
-    fn is_normal_close(e: &std::io::Error) -> bool {
-        matches!(
-            e.kind(),
-            std::io::ErrorKind::BrokenPipe
-                | std::io::ErrorKind::ConnectionReset
-                | std::io::ErrorKind::ConnectionAborted
-                | std::io::ErrorKind::UnexpectedEof
-        )
-    }
-}
-
-impl<T: AsyncRead + Unpin> AsyncRead for IdleTimeoutStream<T> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        self.check_idle()?;
-
-        let initial_filled = buf.filled().len();
-        let poll = Pin::new(&mut self.inner).poll_read(cx, buf);
-
-        match &poll {
-            Poll::Ready(Ok(())) if buf.filled().len() > initial_filled => {
-                self.update_activity();
-            }
-            Poll::Ready(Err(e)) if Self::is_normal_close(e) => {
-                return Poll::Ready(Ok(()));
-            }
-            _ => {}
-        }
-
-        poll
-    }
-}
-
-impl<T: AsyncWrite + Unpin> AsyncWrite for IdleTimeoutStream<T> {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, Error>> {
-        self.check_idle()?;
-
-        let poll = Pin::new(&mut self.inner).poll_write(cx, buf);
-
-        match poll {
-            Poll::Ready(Ok(n)) => {
-                if n > 0 {
-                    self.update_activity();
-                }
-                Poll::Ready(Ok(n))
-            }
-            Poll::Ready(Err(e)) if Self::is_normal_close(&e) => {
-                // Treat normal close as successful write of all bytes
-                Poll::Ready(Ok(buf.len()))
-            }
-            _ => poll,
-        }
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
 }

--- a/src/gateway/relay_udp.rs
+++ b/src/gateway/relay_udp.rs
@@ -20,7 +20,7 @@ use url::Url;
 use super::{common, nat::Session};
 use crate::{gateway::stats, runtime::ArcRuntime};
 
-const UDP_BUFFER_SIZE: usize = 1500;
+const UDP_BUFFER_SIZE: usize = 4096;
 const UDP_ASSOCIATE_TIMEOUT: Duration = Duration::from_secs(5);
 const UDP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const UDP_ASSOCIATION_TTL: Duration = Duration::from_secs(20);

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -13,7 +13,7 @@ use pnet::packet::{
 };
 use std::{
     io::Error,
-    net::Ipv4Addr,
+    net::{Ipv4Addr, TcpListener},
     process::{self, Command},
     str::FromStr,
     sync::Arc,
@@ -53,8 +53,8 @@ impl Gateway {
             IpNet::V6(_) => panic!("IPv6 not supported yet"),
         };
 
-        let relay_port = std::net::TcpListener::bind("127.0.0.1:0")
-            .expect("Failed to bind to random port")
+        let relay_listener = TcpListener::bind("0.0.0.0:0").expect("Failed to bind relay listener");
+        let relay_port = relay_listener
             .local_addr()
             .expect("Failed to get local address")
             .port();
@@ -63,11 +63,7 @@ impl Gateway {
         let tcp_nat = Arc::new(Nat::new(Type::Tcp, None));
         let udp_nat = Arc::new(Nat::new(Type::Udp, Some(tx)));
         let udp_relay = UdpRelay::new(runtime.clone(), rx);
-        let tcp_relay = TcpRelay::new(
-            runtime.clone(),
-            format!("{}:{}", network.addr(), relay_port),
-            tcp_nat.clone(),
-        );
+        let tcp_relay = TcpRelay::new(runtime.clone(), relay_listener, tcp_nat.clone());
 
         Self {
             runtime,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Refactored idle timeout mechanism in TcpRelay to avoid prematurely closing Keep-Alive connections (e.g., in Chrome). Swapped out the custom active polling with tokio::select! to correctly close idle sockets without triggering TCP RST packets.