### PR TITLE
Fix UDP association lifecycle issues causing sporadic QUIC/HTTP3 failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         run: cat CHANGELOG.md
 
       - name: Build | Add Artifacts to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -166,15 +166,9 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blocking"
@@ -230,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -258,7 +252,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -393,9 +387,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -521,11 +515,11 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -676,13 +670,13 @@ dependencies = [
 
 [[package]]
 name = "getifaddrs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802c6e75f730346652928a55c200ca680741aaaa60c4973d52a999f520c4fde4"
+checksum = "a542e1b7ac1f3d62c5777d430d66eca9cb59e813c46b86e29fa9ce94ff9a4810"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -692,10 +686,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -705,9 +697,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -719,7 +713,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -732,9 +726,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -760,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -798,7 +792,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "serde",
  "thiserror 2.0.18",
@@ -821,7 +815,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -1057,12 +1051,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1073,7 +1067,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -1132,9 +1126,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1145,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1156,10 +1150,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1176,11 +1172,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
 ]
 
@@ -1212,7 +1208,7 @@ dependencies = [
  "parking_lot",
  "pnet",
  "prometheus",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "serde_yaml",
@@ -1236,9 +1232,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1366,7 +1362,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
@@ -1378,7 +1374,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
@@ -1401,7 +1397,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1410,11 +1406,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1433,7 +1429,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1463,7 +1459,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1664,9 +1660,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -1730,7 +1726,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hex",
  "procfs-core",
  "rustix 0.38.44",
@@ -1742,7 +1738,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hex",
 ]
 
@@ -1806,9 +1802,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1816,13 +1812,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1846,15 +1842,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1876,7 +1872,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1948,7 +1944,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1961,7 +1957,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1997,9 +1993,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2154,7 +2150,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2274,9 +2270,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2291,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2363,9 +2359,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tun-rs"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aed038a26d2b6a7906a62b3d0c42fb77541b0a695b9c2b9489a0c25c093ce8b"
+checksum = "d81d4007ae1904e2e00028dc0215f0d2ca5af18acdf8664fb75ae6c9a20b98c7"
 dependencies = [
  "blocking",
  "byteorder",
@@ -2378,7 +2374,7 @@ dependencies = [
  "libloading",
  "log",
  "netconfig-rs",
- "nix 0.31.2",
+ "nix 0.31.3",
  "route_manager",
  "scopeguard",
  "tokio",
@@ -2438,9 +2434,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2474,11 +2470,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2487,14 +2483,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2505,9 +2501,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2515,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2528,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -2563,7 +2559,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2919,12 +2915,12 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2935,6 +2931,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2985,7 +2987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -3017,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"

--- a/src/gateway/nat.rs
+++ b/src/gateway/nat.rs
@@ -20,7 +20,7 @@ pub struct SessionKey {
     pub dst_port: u16,
 }
 
-const EPHEMERAL_PORT_START: u16 = 49152;
+const EPHEMERAL_PORT_START: u16 = 1024;
 const EPHEMERAL_PORT_END: u16 = 65535;
 const EPHEMERAL_PORT_RANGE: u16 = EPHEMERAL_PORT_END - EPHEMERAL_PORT_START + 1;
 

--- a/src/gateway/relay_udp.rs
+++ b/src/gateway/relay_udp.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -12,7 +15,7 @@ use moka::sync::Cache;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpStream, UdpSocket},
-    sync::{Mutex, mpsc::UnboundedReceiver},
+    sync::{Mutex, Notify, mpsc::UnboundedReceiver},
     time::timeout,
 };
 use url::Url;
@@ -22,16 +25,13 @@ use crate::{gateway::stats, runtime::ArcRuntime};
 
 const UDP_BUFFER_SIZE: usize = 4096;
 const UDP_ASSOCIATE_TIMEOUT: Duration = Duration::from_secs(5);
-const UDP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-const UDP_ASSOCIATION_TTL: Duration = Duration::from_secs(20);
-const SOCKS5_UDP_HEADER_MIN: usize = 10; // Minimum for IPv4: RSV(2) + FRAG(1) + ATYP(1) + IPv4(4) + PORT(2)
+const UDP_ASSOCIATION_TTL: Duration = Duration::from_secs(300);
+const SOCKS5_UDP_HEADER_MIN: usize = 10;
 
-// SOCKS5 Address Types
-const ATYP_IPV4: u8 = 1; // IPv4 address
-const ATYP_DOMAIN: u8 = 3; // Domain name
-const ATYP_IPV6: u8 = 4; // IPv6 address
+const ATYP_IPV4: u8 = 1;
+const ATYP_DOMAIN: u8 = 3;
+const ATYP_IPV6: u8 = 4;
 
-/// SOCKS5 reply descriptions indexed by reply code
 const SOCKS5_REPLIES: [&str; 9] = [
     "succeeded",
     "general SOCKS server failure",
@@ -44,15 +44,15 @@ const SOCKS5_REPLIES: [&str; 9] = [
     "address type not supported",
 ];
 
-/// UDP Association maintains the SOCKS5 UDP ASSOCIATE control channel and UDP socket
 struct UdpAssociation {
     _control: TcpStream,
-    socket: Arc<UdpSocket>,
+    socket: UdpSocket,
     addr: SocketAddr,
+    active: AtomicBool,
+    notify: Arc<Notify>,
 }
 
 impl UdpAssociation {
-    /// Create a new SOCKS5 UDP association
     async fn new(proxy_url: &str, nat_port: u16) -> Result<Self> {
         let url = Url::parse(proxy_url)?;
         let host = url.host().ok_or_else(|| anyhow!("missing host"))?;
@@ -61,7 +61,6 @@ impl UdpAssociation {
         let proxy_addr = format!("{}:{}", host, port);
         let mut tcp_control = TcpStream::connect(&proxy_addr).await?;
 
-        // SOCKS5 handshake
         if url.username() != "" {
             Self::perform_auth(
                 &mut tcp_control,
@@ -75,25 +74,26 @@ impl UdpAssociation {
 
         let addr = Self::perform_udp_associate(&mut tcp_control).await?;
 
-        // Some SOCKS5 proxies return 0.0.0.0 but expect UDP on the same port as TCP
         let addr = if addr.ip().is_unspecified() {
-            // Use the same host as the TCP connection but the port returned by UDP ASSOCIATE
             let peer_addr = tcp_control.peer_addr()?;
             SocketAddr::new(peer_addr.ip(), addr.port())
         } else {
             addr
         };
 
-        let socket = Arc::new(UdpSocket::bind(format!("0.0.0.0:{}", nat_port)).await?);
+        let socket = UdpSocket::bind(format!("0.0.0.0:{}", nat_port)).await?;
+        let active = AtomicBool::new(true);
+        let notify = Arc::new(Notify::new());
 
         Ok(Self {
             _control: tcp_control,
             socket,
             addr,
+            active,
+            notify,
         })
     }
 
-    /// Send UDP data through the SOCKS5 proxy
     async fn send(&self, data: &Bytes) -> Result<usize> {
         self.socket
             .send_to(data, self.addr)
@@ -101,59 +101,54 @@ impl UdpAssociation {
             .map_err(|e| e.into())
     }
 
-    /// Receive UDP data from the SOCKS5 proxy
     async fn recv(&self) -> Result<Option<Bytes>> {
-        let mut buf = BytesMut::zeroed(UDP_BUFFER_SIZE);
-        match timeout(UDP_RESPONSE_TIMEOUT, self.socket.recv_from(&mut buf))
-            .await
-            .map_err(|e| anyhow!("UDP receive timeout: {}", e))?
-            .map(|(len, _)| len)
-        {
-            Ok(len) => {
-                buf.truncate(len);
-                Ok(Some(buf.freeze()))
-            }
-            Err(e) => {
-                debug!("receive error:{}", e);
-                Ok(None)
+        let mut buf = [0u8; UDP_BUFFER_SIZE];
+
+        loop {
+            tokio::select! {
+                result = self.socket.recv_from(&mut buf) => {
+                    match result {
+                        Ok((len, _)) => return Ok(Some(Bytes::copy_from_slice(&buf[..len]))),
+                        Err(e) => {
+                            debug!("receive error: {}", e);
+                            return Ok(None);
+                        }
+                    }
+                }
+                _ = self.notify.notified() => {
+                    if !self.active.load(Ordering::Relaxed) {
+                        return Ok(None);
+                    }
+                }
             }
         }
     }
 
-    /// Encode SOCKS5 UDP datagram: [RSV(2) | FRAG | ATYP | DST.ADDR | DST.PORT | DATA]
-    ///
-    /// Always use domain name (ATYP=3) to let SOCKS5 proxy server resolve the address.
-    /// This is essential for DNS hijacking scenarios where we need the proxy to resolve
-    /// the original domain name instead of connecting to the hijacked IP.
+    fn deactivate(&self) {
+        self.active.store(false, Ordering::Relaxed);
+        self.notify.notify_one();
+    }
+
     fn encode_socks5_udp(&self, target_addr: &str, target_port: u16, data: &[u8]) -> Result<Bytes> {
         if target_addr.len() > 255 {
             return Err(anyhow!("Domain name too long"));
         }
 
-        // SOCKS5 UDP header: RSV(2) | FRAG(1) | ATYP(1) | DOMAIN_LEN(1) | DOMAIN | DST.PORT(2) | DATA
-        let header_size = 7 + target_addr.len(); // 2+1+1+1+domain_len+2 = 7+domain_len
+        let header_size = 7 + target_addr.len();
         let total_size = header_size + data.len();
         let mut encoded = BytesMut::with_capacity(total_size);
 
-        // RSV (2 bytes)
         encoded.extend_from_slice(&[0, 0]);
-        // FRAG (1 byte)
         encoded.put_u8(0);
-        // ATYP (1 byte) - 3 for domain name
         encoded.put_u8(ATYP_DOMAIN);
-        // Domain length (1 byte)
         encoded.put_u8(target_addr.len() as u8);
-        // Domain
         encoded.extend_from_slice(target_addr.as_bytes());
-        // Port (2 bytes)
         encoded.extend_from_slice(&target_port.to_be_bytes());
-        // Data
         encoded.extend_from_slice(data);
 
         Ok(encoded.freeze())
     }
 
-    /// Decode SOCKS5 UDP datagram from proxy response
     fn decode_socks5_udp(buf: &[u8]) -> Result<(String, u16, Bytes)> {
         if buf.len() < SOCKS5_UDP_HEADER_MIN {
             return Err(anyhow!("UDP datagram too short"));
@@ -188,7 +183,7 @@ impl UdpAssociation {
                 if buf.len() < 22 {
                     return Err(anyhow!("Truncated IPv6 address"));
                 }
-                let octets = &buf[4..20]; // 16 bytes of IPv6 address
+                let octets = &buf[4..20];
                 let mut arr = [0u8; 16];
                 arr.copy_from_slice(octets);
                 (std::net::Ipv6Addr::from(arr).to_string(), 20)
@@ -206,17 +201,25 @@ impl UdpAssociation {
         Ok((addr, port, data))
     }
 
-    /// SOCKS5 authentication with username/password
-    async fn perform_auth(stream: &mut TcpStream, username: &str, password: &str) -> Result<()> {
-        let auth_methods = vec![5u8, 1, 2];
-        stream.write_all(&auth_methods).await?;
+    async fn send_auth_methods(stream: &mut TcpStream, methods: &[u8]) -> Result<u8> {
+        let mut buf = BytesMut::with_capacity(2 + methods.len());
+        buf.put_u8(5);
+        buf.put_u8(methods.len() as u8);
+        buf.extend_from_slice(methods);
+        stream.write_all(&buf).await?;
 
         let mut response = [0u8; 2];
         stream.read_exact(&mut response).await?;
 
-        if response[1] != 2 {
+        Ok(response[1])
+    }
+
+    async fn perform_auth(stream: &mut TcpStream, username: &str, password: &str) -> Result<()> {
+        let method = Self::send_auth_methods(stream, &[2]).await?;
+        if method != 2 {
             return Err(anyhow!("Server doesn't support username/password auth"));
         }
+
         let auth_len = 1 + 1 + username.len().min(255) + 1 + password.len().min(255);
         let mut auth_req = BytesMut::with_capacity(auth_len);
         auth_req.put_u8(1);
@@ -236,24 +239,16 @@ impl UdpAssociation {
         Ok(())
     }
 
-    /// SOCKS5 no authentication
     async fn perform_no_auth(stream: &mut TcpStream) -> Result<()> {
-        let auth_methods = vec![5u8, 1, 0];
-        stream.write_all(&auth_methods).await?;
-
-        let mut response = [0u8; 2];
-        stream.read_exact(&mut response).await?;
-
-        if response[1] != 0 {
+        let method = Self::send_auth_methods(stream, &[0]).await?;
+        if method != 0 {
             return Err(anyhow!("Server doesn't support no auth"));
         }
-
         Ok(())
     }
 
-    /// Perform SOCKS5 UDP ASSOCIATE and return the UDP relay address
     async fn perform_udp_associate(stream: &mut TcpStream) -> Result<SocketAddr> {
-        let mut request = BytesMut::with_capacity(10); // Fixed size for UDP ASSOCIATE request
+        let mut request = BytesMut::with_capacity(10);
         request.put_u8(5);
         request.put_u8(3);
         request.put_u8(0);
@@ -324,13 +319,16 @@ pub(crate) struct UdpRelay {
 }
 
 impl UdpRelay {
-    pub fn new(runtime: ArcRuntime, rx: UnboundedReceiver<u16>) -> Self {
-        let associations = Cache::builder().time_to_idle(UDP_ASSOCIATION_TTL).build();
+    pub fn new(runtime: ArcRuntime, mut rx: UnboundedReceiver<u16>) -> Self {
+        let associations: Cache<u16, Arc<UdpAssociation>> =
+            Cache::builder().time_to_idle(UDP_ASSOCIATION_TTL).build();
 
         let invalidates = associations.clone();
         tokio::spawn(async move {
-            let mut rx = rx;
             while let Some(nat_port) = rx.recv().await {
+                if let Some(assoc) = invalidates.get(&nat_port) {
+                    assoc.deactivate();
+                }
                 invalidates.invalidate(&nat_port);
             }
         });
@@ -367,6 +365,7 @@ impl UdpRelay {
         let _guard = pending_lock.lock().await;
 
         if let Some(assoc) = self.associations.get(&nat_port) {
+            self.lock.lock().await.remove(&nat_port);
             return Ok(assoc);
         }
 
@@ -385,13 +384,27 @@ impl UdpRelay {
 
         let proxy_url = common::random_proxy(&proxy_config.values);
 
-        let assoc = timeout(
+        let result = timeout(
             UDP_ASSOCIATE_TIMEOUT,
             UdpAssociation::new(&proxy_url, nat_port),
         )
-        .await??;
+        .await;
+
+        let assoc = match result {
+            Ok(Ok(assoc)) => assoc,
+            Ok(Err(e)) => {
+                self.lock.lock().await.remove(&nat_port);
+                return Err(e);
+            }
+            Err(_) => {
+                self.lock.lock().await.remove(&nat_port);
+                return Err(anyhow!("UDP ASSOCIATE timeout"));
+            }
+        };
+
         let assoc = Arc::new(assoc);
         self.associations.insert(nat_port, assoc.clone());
+        self.lock.lock().await.remove(&nat_port);
 
         let assoc_clone = assoc.clone();
         let runtime = self.runtime.clone();
@@ -413,8 +426,6 @@ impl UdpRelay {
                     );
                 }
             }
-            // Receive loop ended (timeout or error) - invalidate this association immediately
-            // to force recreation on next request instead of waiting for TTL expiration
             log::debug!(
                 "UDP receive loop ended for proxy {} (nat_port: {}), invalidating association",
                 proxy_name,
@@ -439,7 +450,7 @@ impl UdpRelay {
         let nat_port = session.nat_port;
         let target = self.find_target(session).await?;
         let (proxy_name, target_host, target_port) = target;
-        let max_payload = UDP_BUFFER_SIZE - (SOCKS5_UDP_HEADER_MIN + target_host.len());
+        let max_payload = UDP_BUFFER_SIZE - (7 + target_host.len());
         if payload.len() > max_payload {
             log::warn!(
                 "UDP payload too large: {} > {} (host: {}, nat_port: {})",
@@ -457,7 +468,19 @@ impl UdpRelay {
 
         let encoded = assoc.encode_socks5_udp(&target_host, target_port, payload)?;
 
-        let _ = assoc.send(&encoded).await?;
+        if let Err(e) = assoc.send(&encoded).await {
+            log::warn!(
+                "UDP send failed for {}:{} via proxy {} (nat_port: {}): {}",
+                target_host,
+                target_port,
+                proxy_name,
+                nat_port,
+                e
+            );
+            assoc.deactivate();
+            self.associations.invalidate(&nat_port);
+            return Err(e);
+        }
 
         stats::update_metrics(
             &self.runtime,


### PR DESCRIPTION
Fix UDP association lifecycle causing sporadic QUIC/HTTP3 failures:

- Extend UDP_ASSOCIATION_TTL from 20s to 300s
- Replace timeout polling with Notify for instant socket release on send errors
- Expand NAT ephemeral port range from 49152-65535 to 1024-65535
- Clean up lock HashMap leaks after association creation
- Remove redundant Arc wrapping (socket, AtomicBool)
- Use stack buffer in recv() to avoid heap allocations

Also bumps dependencies and upgrades action-gh-release to v3.
