### PR TITLE
Upgrade hickory-server to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -300,6 +300,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -424,18 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -713,7 +711,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -777,24 +775,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
- "serde",
+ "jni",
+ "rand",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -803,22 +799,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -826,16 +848,16 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "ipnet",
@@ -1149,6 +1171,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,7 +1279,7 @@ dependencies = [
  "parking_lot",
  "pnet",
  "prometheus",
- "rand 0.10.1",
+ "rand",
  "rayon",
  "serde",
  "serde_yaml",
@@ -1325,6 +1396,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netconfig-rs"
@@ -1683,20 +1760,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prefix-trie"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
+ "either",
  "ipnet",
  "num-traits",
 ]
@@ -1802,42 +1871,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1936,6 +1976,15 @@ dependencies = [
  "netlink-packet-route 0.28.0",
  "netlink-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2068,6 +2117,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -3044,26 +3109,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ env_logger = "0.11"
 fast-socks5 = "1"
 futures = "0.3"
 glob = "0.3"
-hickory-server = { version = "0.25", features = ["resolver"] }
+hickory-server = { version = "0.26", features = ["resolver"] }
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }

--- a/src/config/dns_table.rs
+++ b/src/config/dns_table.rs
@@ -1,11 +1,7 @@
 use bimap::BiMap;
-use hickory_server::{
-    authority::LookupObject,
-    proto::rr::{
-        RData, Record,
-        rdata::{A, AAAA, TXT},
-    },
-    resolver::Name,
+use hickory_server::proto::rr::{
+    Name, RData, Record,
+    rdata::{A, AAAA, TXT},
 };
 use ipnet::IpNet;
 use moka::sync::Cache;
@@ -74,11 +70,9 @@ impl DnsTable {
             .eviction_listener({
                 let mapping = Arc::clone(&mapping);
                 move |domain: Arc<String>, _addr: Arc<Addr>, _cause| {
-                    // Use try_write for eviction listener to avoid blocking
                     if let Ok(mut mapping_guard) = mapping.try_write() {
                         mapping_guard.remove_by_left(&*domain);
                     }
-                    // If lock is busy, stale entry will be cleaned up on next access
                 }
             })
             .build();
@@ -116,7 +110,6 @@ impl DnsTable {
             if let Some(addr) = self.cache.get(&domain) {
                 return Some((*addr).clone());
             }
-            // Remove stale entry from mapping
             let mut mapping = self.mapping.write().await;
             mapping.remove_by_right(ip);
         }
@@ -134,7 +127,6 @@ impl DnsTable {
         };
 
         if has_mapping {
-            // Remove stale entry from mapping
             let mut mapping = self.mapping.write().await;
             mapping.remove_by_left(domain);
         }
@@ -159,7 +151,6 @@ impl DnsTable {
     pub async fn clear(&self) {
         self.cache.invalidate_all();
 
-        // Clear the mapping atomically
         let mut mapping = self.mapping.write().await;
         mapping.clear();
     }
@@ -225,19 +216,16 @@ impl Addr {
             records,
         }
     }
-}
 
-impl LookupObject for Addr {
-    fn is_empty(&self) -> bool {
-        self.records.is_empty()
-    }
+    pub fn to_auth_lookup(&self) -> hickory_server::zone_handler::AuthLookup {
+        use hickory_server::zone_handler::{AuthLookup, LookupRecords};
 
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Record> + Send + 'a> {
-        Box::new(self.records.iter())
-    }
+        if self.records.is_empty() {
+            return AuthLookup::default();
+        }
 
-    fn take_additionals(&mut self) -> Option<Box<dyn LookupObject>> {
-        None
+        let records = LookupRecords::Section(self.records.clone());
+        AuthLookup::answers(records, None)
     }
 }
 
@@ -352,7 +340,6 @@ mod tests {
         table.cache.invalidate("test.com");
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Verify mapping is also cleared (proves cache and mapping share the same Arc)
         assert!(table.find_by_ip(&ip).await.is_none());
     }
 

--- a/src/config/dns_table.rs
+++ b/src/config/dns_table.rs
@@ -87,7 +87,7 @@ impl DnsTable {
         }
     }
 
-    pub async fn apply(&self, domain: &str, target: &str, remark: &str) -> Addr {
+    pub async fn apply(&self, domain: &str, target: &str, remark: &str) -> Arc<Addr> {
         let ip = self.allocate_addr();
         let addr = Arc::new(Addr::new(domain, Some(ip), target, remark));
 
@@ -97,10 +97,10 @@ impl DnsTable {
         let mut mapping = self.mapping.write().await;
         mapping.insert(domain_owned, ip);
 
-        (*addr).clone()
+        addr
     }
 
-    pub async fn find_by_ip(&self, ip: &IpAddr) -> Option<Addr> {
+    pub async fn find_by_ip(&self, ip: &IpAddr) -> Option<Arc<Addr>> {
         let domain = {
             let mapping = self.mapping.read().await;
             mapping.get_by_right(ip).cloned()
@@ -108,7 +108,7 @@ impl DnsTable {
 
         if let Some(domain) = domain {
             if let Some(addr) = self.cache.get(&domain) {
-                return Some((*addr).clone());
+                return Some(addr);
             }
             let mut mapping = self.mapping.write().await;
             mapping.remove_by_right(ip);
@@ -116,9 +116,9 @@ impl DnsTable {
         None
     }
 
-    pub async fn find_by_domain(&self, domain: &str) -> Option<Option<Addr>> {
+    pub async fn find_by_domain(&self, domain: &str) -> Option<Option<Arc<Addr>>> {
         if let Some(addr) = self.cache.get(domain) {
-            return Some(Some((*addr).clone()));
+            return Some(Some(addr));
         }
 
         let has_mapping = {
@@ -134,7 +134,7 @@ impl DnsTable {
         None
     }
 
-    pub async fn allocate(&self, domain: &str, ip: Option<IpAddr>, remark: &str) -> Addr {
+    pub async fn allocate(&self, domain: &str, ip: Option<IpAddr>, remark: &str) -> Arc<Addr> {
         let addr = Arc::new(Addr::new(domain, ip, "", remark));
 
         let domain_owned = domain.to_string();
@@ -145,7 +145,7 @@ impl DnsTable {
             mapping.insert(domain_owned, ip_addr);
         }
 
-        (*addr).clone()
+        addr
     }
 
     pub async fn clear(&self) {

--- a/src/dns/dns_handler.rs
+++ b/src/dns/dns_handler.rs
@@ -1,14 +1,12 @@
 use hickory_server::{
-    authority::{
-        AuthLookup, AuthorityObject, LookupControlFlow, LookupError, LookupObject, LookupOptions,
-        LookupRecords,
-    },
     proto::{
         op::ResponseCode,
-        rr::{LowerName, RData, RecordSet, RecordType, rdata::PTR},
+        rr::{LowerName, Name, RData, RecordSet, RecordType, rdata::PTR},
     },
-    resolver::Name,
-    server::RequestInfo,
+    server::{Request, RequestInfo},
+    zone_handler::{
+        AuthLookup, LookupControlFlow, LookupError, LookupOptions, LookupRecords, ZoneHandler,
+    },
 };
 use log::{debug, error};
 use prometheus::{IntCounter, register_int_counter};
@@ -25,11 +23,11 @@ use crate::runtime::ArcRuntime;
 
 pub(crate) struct DnsHandler {
     runtime: ArcRuntime,
-    upstream: Arc<dyn AuthorityObject>,
+    upstream: Arc<dyn ZoneHandler>,
 }
 
 impl DnsHandler {
-    pub(crate) fn new(runtime: ArcRuntime, upstream: Arc<dyn AuthorityObject>) -> Self {
+    pub(crate) fn new(runtime: ArcRuntime, upstream: Arc<dyn ZoneHandler>) -> Self {
         Self { runtime, upstream }
     }
 
@@ -64,9 +62,13 @@ impl DnsHandler {
 
     pub(crate) async fn handle(
         &self,
-        request_info: RequestInfo<'_>,
+        request: &Request,
         lookup_options: LookupOptions,
-    ) -> Result<Box<dyn LookupObject>, LookupError> {
+    ) -> Result<AuthLookup, LookupError> {
+        let request_info = request
+            .request_info()
+            .map_err(|_| LookupError::ResponseCode(ResponseCode::FormErr))?;
+
         let query = request_info.query;
         let should_handle = query.query_type() == RecordType::A;
 
@@ -85,7 +87,6 @@ impl DnsHandler {
             return Err(LookupError::ResponseCode(ResponseCode::BADNAME));
         }
 
-        // metrics
         if self.runtime.setting.metrics.is_some() {
             lazy_static! {
                 static ref DNS_QUERY: IntCounter =
@@ -104,7 +105,7 @@ impl DnsHandler {
                 records.add_rdata(RData::PTR(PTR(name)));
                 let answers = LookupRecords::new(Default::default(), Arc::new(records));
                 let result = AuthLookup::answers(answers, None);
-                return Ok(Box::new(result));
+                return Ok(result);
             }
         }
 
@@ -114,19 +115,19 @@ impl DnsHandler {
             let addr = self.runtime.dns_table.find_by_domain(domain).await;
             match addr {
                 Some(Some(v)) => {
-                    return Ok(Box::new(v));
+                    return Ok(v.to_auth_lookup());
                 }
                 None => {
                     debug!("query src: {:?}, domain: {}", request_info.src.ip(), domain);
 
                     matching_rules = true;
 
-                    if let Some(v) = self.handle_hosts(domain).await {
-                        return Ok(Box::new(v));
+                    if let Some(v) = self.handle_hosts(domain, &request_info).await {
+                        return Ok(v.to_auth_lookup());
                     }
 
                     if let Some(v) = self.apply_before_rules(domain).await {
-                        return Ok(Box::new(v));
+                        return Ok(v.to_auth_lookup());
                     }
                 }
                 _ => {}
@@ -135,33 +136,34 @@ impl DnsHandler {
 
         let search_result = timeout(
             Duration::from_secs(2),
-            self.upstream.search(request_info, lookup_options),
+            self.upstream.search(request, lookup_options),
         )
         .await
         .map_err(|_| LookupError::ResponseCode(ResponseCode::ServFail))?;
 
-        let result = match search_result {
-            LookupControlFlow::Continue(lookup) => lookup,
-            LookupControlFlow::Break(lookup) => lookup,
+        let (flow, _tsig) = search_result;
+        let result = match flow {
+            LookupControlFlow::Continue(r) => r,
+            LookupControlFlow::Break(r) => r,
             LookupControlFlow::Skip => Err(LookupError::ResponseCode(ResponseCode::ServFail)),
         };
 
         if should_handle && matching_rules {
             match result {
-                Ok(r) => {
+                Ok(ref r) => {
                     let ips: Vec<IpAddr> = r
                         .iter()
-                        .filter_map(|record| match record.data() {
+                        .filter_map(|record| match &record.data {
                             RData::A(v) => Some(IpAddr::V4(**v)),
                             _ => None,
                         })
                         .collect();
 
                     if let Some(v) = self.apply_post_rules(domain, ips).await {
-                        return Ok(Box::new(v));
+                        return Ok(v.to_auth_lookup());
                     }
 
-                    return Ok(r);
+                    return result;
                 }
                 _ => return result,
             }
@@ -169,7 +171,11 @@ impl DnsHandler {
         result
     }
 
-    pub(crate) async fn handle_hosts(&self, domain: &str) -> Option<Addr> {
+    pub(crate) async fn handle_hosts(
+        &self,
+        domain: &str,
+        request_info: &RequestInfo<'_>,
+    ) -> Option<Addr> {
         let m = self.runtime.hosts.load().match_domain(domain)?;
 
         if let Ok(ip) = IpAddr::from_str(&m) {
@@ -192,15 +198,15 @@ impl DnsHandler {
             .lookup(
                 &LowerName::new(&name.unwrap()),
                 RecordType::A,
+                Some(request_info),
                 LookupOptions::default(),
             )
             .await;
 
         match r {
-            LookupControlFlow::Continue(Ok(v)) => {
+            LookupControlFlow::Continue(Ok(v)) | LookupControlFlow::Break(Ok(v)) => {
                 for record in v.iter() {
-                    let data = record.data();
-                    if let Some(a_record) = data.as_a() {
+                    if let RData::A(a_record) = &record.data {
                         return Some(
                             self.runtime
                                 .dns_table
@@ -211,25 +217,7 @@ impl DnsHandler {
                 }
                 None
             }
-            LookupControlFlow::Continue(Err(e)) => {
-                error!("{:?}", e);
-                None
-            }
-            LookupControlFlow::Break(Ok(v)) => {
-                for record in v.iter() {
-                    let data = record.data();
-                    if let Some(a_record) = data.as_a() {
-                        return Some(
-                            self.runtime
-                                .dns_table
-                                .allocate(domain, Some(IpAddr::V4(**a_record)), "host")
-                                .await,
-                        );
-                    }
-                }
-                None
-            }
-            LookupControlFlow::Break(Err(e)) => {
+            LookupControlFlow::Continue(Err(e)) | LookupControlFlow::Break(Err(e)) => {
                 error!("{:?}", e);
                 None
             }
@@ -238,12 +226,10 @@ impl DnsHandler {
     }
 
     pub(crate) async fn apply_before_rules(&self, domain: &str) -> Option<Addr> {
-        // Check exclude rules first
         if self.runtime.rules.find_exclude_domain(domain) {
             return None;
         }
 
-        // Find domain-based rule
         if let Some(matched) = self.runtime.rules.find_domain_rule(domain) {
             let remark = format!(
                 "rule:{:?}, value:{}, target:{}",

--- a/src/dns/dns_handler.rs
+++ b/src/dns/dns_handler.rs
@@ -175,7 +175,7 @@ impl DnsHandler {
         &self,
         domain: &str,
         request_info: &RequestInfo<'_>,
-    ) -> Option<Addr> {
+    ) -> Option<Arc<Addr>> {
         let m = self.runtime.hosts.load().match_domain(domain)?;
 
         if let Ok(ip) = IpAddr::from_str(&m) {
@@ -225,7 +225,7 @@ impl DnsHandler {
         }
     }
 
-    pub(crate) async fn apply_before_rules(&self, domain: &str) -> Option<Addr> {
+    pub(crate) async fn apply_before_rules(&self, domain: &str) -> Option<Arc<Addr>> {
         if self.runtime.rules.find_exclude_domain(domain) {
             return None;
         }
@@ -248,7 +248,11 @@ impl DnsHandler {
         None
     }
 
-    pub(crate) async fn apply_post_rules(&self, domain: &str, ips: Vec<IpAddr>) -> Option<Addr> {
+    pub(crate) async fn apply_post_rules(
+        &self,
+        domain: &str,
+        ips: Vec<IpAddr>,
+    ) -> Option<Arc<Addr>> {
         for ip in ips {
             if let Some(matched) = self.runtime.rules.find_dns_cidr_rule(&ip) {
                 let remark = format!(

--- a/src/dns/dns_server.rs
+++ b/src/dns/dns_server.rs
@@ -1,18 +1,19 @@
 use anyhow::Error;
-use hickory_server::proto::rr::LowerName;
+use hickory_server::net::runtime::Time;
+use hickory_server::proto::op::ResponseCode;
+use hickory_server::proto::rr::TSigResponseContext;
+use hickory_server::proto::rr::{LowerName, Name};
+use hickory_server::resolver::config::{
+    ConnectionConfig, NameServerConfig, ProtocolConfig, ResolveHosts, ResolverOpts,
+};
+use hickory_server::server::{Request, RequestHandler, RequestInfo, ResponseHandler, ResponseInfo};
+use hickory_server::store::forwarder::{ForwardConfig, ForwardZoneHandler};
 use hickory_server::{
-    ServerFuture,
-    authority::{
-        AuthorityObject, Catalog, LookupControlFlow, LookupError, LookupObject, LookupOptions,
-        MessageRequest, UpdateResult, ZoneType,
+    Server,
+    zone_handler::{
+        AuthLookup, AxfrPolicy, Catalog, LookupControlFlow, LookupError, LookupOptions,
+        ZoneHandler, ZoneType,
     },
-    proto::{op::ResponseCode, rr::RecordType},
-    resolver::{
-        Name,
-        config::{NameServerConfigGroup, ResolveHosts, ResolverOpts},
-    },
-    server::{Request, RequestHandler, RequestInfo, ResponseHandler, ResponseInfo},
-    store::forwarder::{ForwardAuthority, ForwardConfig},
 };
 use std::net::ToSocketAddrs;
 use std::{sync::Arc, time::Duration};
@@ -24,8 +25,16 @@ use tokio::{
 use super::dns_handler::DnsHandler;
 use crate::runtime::ArcRuntime;
 
-pub(crate) async fn build_dns_server(runtime: ArcRuntime) -> Result<ServerFuture<Handler>, Error> {
-    let mut name_servers = NameServerConfigGroup::with_capacity(runtime.setting.dns_upstream.len());
+fn make_connection_configs(port: u16) -> Vec<ConnectionConfig> {
+    let mut udp = ConnectionConfig::new(ProtocolConfig::Udp);
+    udp.port = port;
+    let mut tcp = ConnectionConfig::new(ProtocolConfig::Tcp);
+    tcp.port = port;
+    vec![udp, tcp]
+}
+
+pub(crate) async fn build_dns_server(runtime: ArcRuntime) -> Result<Server<Handler>, Error> {
+    let mut name_servers = Vec::new();
     for upstream in runtime.setting.dns_upstream.iter() {
         let mut upstream = upstream.clone();
         if !upstream.contains(':') {
@@ -34,19 +43,16 @@ pub(crate) async fn build_dns_server(runtime: ArcRuntime) -> Result<ServerFuture
 
         if let Ok(addrs) = &upstream[..].to_socket_addrs() {
             addrs.clone().for_each(|addr| {
-                let name_server =
-                    NameServerConfigGroup::from_ips_clear(&[addr.ip()], addr.port(), true);
-                name_servers.merge(name_server);
+                let mut ns = NameServerConfig::udp_and_tcp(addr.ip());
+                ns.connections = make_connection_configs(addr.port());
+                name_servers.push(ns);
             });
         }
     }
 
-    // optimize for forward / upstream
     let mut opts = ResolverOpts::default();
     opts.attempts = 1;
-    opts.check_names = false;
     opts.use_hosts_file = ResolveHosts::Never;
-    opts.validate = false;
     opts.num_concurrent_reqs = 2;
     opts.try_tcp_on_error = false;
     opts.edns0 = true;
@@ -59,18 +65,18 @@ pub(crate) async fn build_dns_server(runtime: ArcRuntime) -> Result<ServerFuture
         options: Some(opts),
     };
 
-    let upstream = ForwardAuthority::builder_tokio(forward_config)
+    let upstream = ForwardZoneHandler::builder_tokio(forward_config)
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to build forward authority: {}", e))?;
 
-    let upstream = Arc::new(upstream);
+    let upstream: Arc<dyn ZoneHandler> = Arc::new(upstream);
     let handler = DnsHandler::new(runtime.clone(), upstream.clone());
     let authority = HijackAuthority::new(upstream.clone(), handler);
 
     let mut catalog = Catalog::new();
     catalog.upsert(LowerName::from(Name::root()), vec![Arc::new(authority)]);
 
-    let mut server = ServerFuture::new(Handler { catalog });
+    let mut server = Server::new(Handler { catalog });
     log::info!("dns listen port: {}", runtime.setting.dns_port);
     server.register_socket(
         UdpSocket::bind(format!(
@@ -86,30 +92,31 @@ pub(crate) async fn build_dns_server(runtime: ArcRuntime) -> Result<ServerFuture
         ))
         .await?,
         Duration::from_secs(5),
+        1024,
     );
 
     Ok(server)
 }
 
 struct HijackAuthority {
-    upstream: Arc<dyn AuthorityObject>,
+    upstream: Arc<dyn ZoneHandler>,
     handler: DnsHandler,
 }
 
 impl HijackAuthority {
-    fn new(upstream: Arc<dyn AuthorityObject>, handler: DnsHandler) -> Self {
+    fn new(upstream: Arc<dyn ZoneHandler>, handler: DnsHandler) -> Self {
         Self { upstream, handler }
     }
 }
 
 #[async_trait::async_trait]
-impl AuthorityObject for HijackAuthority {
+impl ZoneHandler for HijackAuthority {
     fn zone_type(&self) -> ZoneType {
         self.upstream.zone_type()
     }
 
-    fn is_axfr_allowed(&self) -> bool {
-        self.upstream.is_axfr_allowed()
+    fn axfr_policy(&self) -> AxfrPolicy {
+        self.upstream.axfr_policy()
     }
 
     fn can_validate_dnssec(&self) -> bool {
@@ -120,52 +127,61 @@ impl AuthorityObject for HijackAuthority {
         self.upstream.origin()
     }
 
-    async fn update(&self, update: &MessageRequest) -> UpdateResult<bool> {
-        self.upstream.update(update).await
+    async fn update(
+        &self,
+        update: &Request,
+        now: u64,
+    ) -> (Result<bool, ResponseCode>, Option<TSigResponseContext>) {
+        self.upstream.update(update, now).await
     }
 
     async fn lookup(
         &self,
         name: &LowerName,
-        rtype: RecordType,
+        rtype: hickory_server::proto::rr::RecordType,
+        request_info: Option<&RequestInfo<'_>>,
         lookup_options: LookupOptions,
-    ) -> LookupControlFlow<Box<dyn LookupObject>> {
-        self.upstream.lookup(name, rtype, lookup_options).await
+    ) -> LookupControlFlow<AuthLookup> {
+        self.upstream
+            .lookup(name, rtype, request_info, lookup_options)
+            .await
     }
 
     async fn search(
         &self,
-        request_info: RequestInfo<'_>,
+        request: &Request,
         lookup_options: LookupOptions,
-    ) -> LookupControlFlow<Box<dyn LookupObject>> {
-        let future = self.handler.handle(request_info, lookup_options);
+    ) -> (LookupControlFlow<AuthLookup>, Option<TSigResponseContext>) {
+        let future = self.handler.handle(request, lookup_options);
 
         match time::timeout(Duration::from_millis(2000), future).await {
-            Ok(Ok(r)) => LookupControlFlow::Continue(Ok(r)),
-            Ok(Err(e)) => LookupControlFlow::Break(Err(e)),
-            Err(_) => {
-                LookupControlFlow::Break(Err(LookupError::ResponseCode(ResponseCode::ServFail)))
-            }
+            Ok(Ok(r)) => (LookupControlFlow::Continue(Ok(r)), None),
+            Ok(Err(e)) => (LookupControlFlow::Break(Err(e)), None),
+            Err(_) => (
+                LookupControlFlow::Break(Err(LookupError::ResponseCode(ResponseCode::ServFail))),
+                None,
+            ),
         }
     }
 
-    async fn get_nsec_records(
+    async fn nsec_records(
         &self,
         name: &LowerName,
         lookup_options: LookupOptions,
-    ) -> LookupControlFlow<Box<dyn LookupObject>> {
-        self.upstream.get_nsec_records(name, lookup_options).await
+    ) -> LookupControlFlow<AuthLookup> {
+        self.upstream.nsec_records(name, lookup_options).await
     }
 
     async fn consult(
         &self,
         name: &LowerName,
-        rtype: RecordType,
+        rtype: hickory_server::proto::rr::RecordType,
+        request_info: Option<&RequestInfo<'_>>,
         lookup_options: LookupOptions,
-        lookup: LookupControlFlow<Box<dyn LookupObject>>,
-    ) -> LookupControlFlow<Box<dyn LookupObject>> {
+        last_result: LookupControlFlow<AuthLookup>,
+    ) -> (LookupControlFlow<AuthLookup>, Option<TSigResponseContext>) {
         self.upstream
-            .consult(name, rtype, lookup_options, lookup)
+            .consult(name, rtype, request_info, lookup_options, last_result)
             .await
     }
 }
@@ -176,11 +192,14 @@ pub struct Handler {
 
 #[async_trait::async_trait]
 impl RequestHandler for Handler {
-    async fn handle_request<R: ResponseHandler>(
+    async fn handle_request<R: ResponseHandler, T: Time>(
         &self,
         request: &Request,
         response_handle: R,
     ) -> ResponseInfo {
-        self.catalog.lookup(request, None, response_handle).await
+        let now = T::current_time();
+        self.catalog
+            .lookup(request, None, now, response_handle)
+            .await
     }
 }

--- a/src/gateway/common.rs
+++ b/src/gateway/common.rs
@@ -18,7 +18,7 @@ pub fn random_proxy(proxy: &[String]) -> String {
 /// Find target proxy and address for a session
 pub async fn find_target(runtime: ArcRuntime, session: Session) -> Option<(String, String, u16)> {
     if let Some(addr) = runtime.dns_table.find_by_ip(&session.dst_addr.into()).await {
-        return Some((addr.target, addr.domain, session.dst_port));
+        return Some((addr.target.clone(), addr.domain.clone(), session.dst_port));
     }
 
     if let Some(matched) = runtime.rules.find_route_rule(&IpAddr::V4(session.dst_addr)) {

--- a/src/gateway/nat.rs
+++ b/src/gateway/nat.rs
@@ -25,7 +25,7 @@ const EPHEMERAL_PORT_END: u16 = 65535;
 const EPHEMERAL_PORT_RANGE: u16 = EPHEMERAL_PORT_END - EPHEMERAL_PORT_START + 1;
 
 pub struct Nat {
-    cache: Cache<SessionKey, Arc<Session>>,
+    cache: Cache<SessionKey, Session>,
     mapping: Arc<RwLock<BiMap<SessionKey, u16>>>,
     port_counter: AtomicU16,
 }
@@ -76,22 +76,22 @@ impl Nat {
         };
 
         if let Some(session) = self.cache.get(&addr_key).await {
-            return Ok(*session);
+            return Ok(session);
         }
 
         let nat_port = {
             let mut mapping = self.mapping.write().await;
 
             if let Some(&nat_port) = mapping.get_by_left(&addr_key) {
-                let session = Arc::new(Session {
+                let session = Session {
                     src_addr,
                     dst_addr,
                     src_port,
                     dst_port,
                     nat_port,
-                });
-                self.cache.insert(addr_key, session.clone()).await;
-                return Ok(*session);
+                };
+                self.cache.insert(addr_key, session).await;
+                return Ok(session);
             }
 
             let mut assigned_port = 0;
@@ -114,34 +114,34 @@ impl Nat {
             assigned_port
         };
 
-        let session = Arc::new(Session {
+        let session = Session {
             src_addr,
             dst_addr,
             src_port,
             dst_port,
             nat_port,
-        });
+        };
 
-        self.cache.insert(addr_key, session.clone()).await;
+        self.cache.insert(addr_key, session).await;
 
-        Ok(*session)
+        Ok(session)
     }
 
     pub async fn find(&self, nat_port: u16) -> Option<Session> {
         if let Some(addr_key) = self.get_addr_key_by_port_fast(&nat_port).await {
             if let Some(session) = self.cache.get(&addr_key).await {
-                return Some(*session);
+                return Some(session);
             }
 
-            let session = Arc::new(Session {
+            let session = Session {
                 src_addr: addr_key.src_addr,
                 dst_addr: addr_key.dst_addr,
                 src_port: addr_key.src_port,
                 dst_port: addr_key.dst_port,
                 nat_port,
-            });
-            self.cache.insert(addr_key, session.clone()).await;
-            return Some(*session);
+            };
+            self.cache.insert(addr_key, session).await;
+            return Some(session);
         }
 
         None
@@ -167,23 +167,21 @@ impl Nat {
         ttl: Duration,
         mapping: Arc<RwLock<BiMap<SessionKey, u16>>>,
         tx: Option<UnboundedSender<u16>>,
-    ) -> Cache<SessionKey, Arc<Session>> {
+    ) -> Cache<SessionKey, Session> {
         Cache::builder()
             .max_capacity(10000)
             .time_to_idle(ttl)
-            .eviction_listener(
-                move |addr_key: Arc<SessionKey>, session: Arc<Session>, _cause| {
-                    let mapping = mapping.clone();
-                    let tx = tx.clone();
-                    tokio::task::spawn(async move {
-                        let mut mapping_guard = mapping.write().await;
-                        let _ = mapping_guard.remove_by_left(&*addr_key);
-                        if let Some(ref tx) = tx {
-                            let _ = tx.send(session.nat_port);
-                        }
-                    });
-                },
-            )
+            .eviction_listener(move |addr_key: Arc<SessionKey>, session: Session, _cause| {
+                let mapping = mapping.clone();
+                let tx = tx.clone();
+                tokio::task::spawn(async move {
+                    let mut mapping_guard = mapping.write().await;
+                    let _ = mapping_guard.remove_by_left(&*addr_key);
+                    if let Some(ref tx) = tx {
+                        let _ = tx.send(session.nat_port);
+                    }
+                });
+            })
             .build()
     }
 


### PR DESCRIPTION
- Adapt to 0.26 API: `ZoneHandler`, `Server`, `AuthLookup`
- Return `Arc<Addr>` from DnsTable to avoid cloning on every DNS lookup
- Remove `Arc<Session>` wrapping in NAT table (`Session` is `Copy`)
