### PR TITLE
perf: reduce heap allocations on hot paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ kungfu is a flexible DNS hijacking and proxy tool written in Rust. It provides D
 ## Build and Development Commands
 
 ### Requirements
-- **Rust Nightly Toolchain**: This project requires nightly Rust due to the `#![feature(test)]` feature flag
+- **Rust Nightly Toolchain**: This project requires nightly Rust due to the `#![cfg_attr(test, feature(test))]` feature flag
 - Install with: `rustup toolchain install nightly && rustup default nightly`
 
 ### Common Commands
@@ -52,7 +52,7 @@ cargo fmt
 
 ### Cross-compilation
 The project supports multiple targets (see `.github/workflows/build.yml`):
-- Linux: x86_64, aarch64, arm, armv7, i686 (gnu/musl)
+- Linux: x86_64 (gnu/musl), aarch64 (gnu/musl), arm (musl), armv7 (musl), i686 (musl)
 - macOS: x86_64, aarch64
 
 Use `cross` for cross-compilation on Linux targets:
@@ -79,10 +79,11 @@ src/
 ├── cli.rs            # Command-line argument parsing
 ├── logger.rs         # Logging initialization
 ├── metrics.rs        # Prometheus metrics HTTP server
-├── runtime.rs        # Runtime configuration management
+├── runtime/          # Runtime configuration management
+│   └── mod.rs
 ├── config/           # Configuration management
 │   ├── mod.rs
-│   ├── setting.rs    # Core config structures (Setting, Proxy, Rule)
+│   ├── setting.rs    # Core config structures (Setting, Proxy)
 │   ├── load.rs       # Config file loading and hot-reload
 │   ├── dns_table.rs  # IP address allocation for hijacked domains
 │   └── hosts.rs      # Host file parsing with CNAME/glob support
@@ -138,10 +139,8 @@ src/
   - Custom stack size: 256KB per thread
   - Thread name: `kungfu-worker`
 
-- **Rayon Thread Pool**: Parallel processing for rule/pattern matching
-  - Thread count: `max(2, num_cpus)`
-  - Thread name: `kungfu-rayon`
-  - Used in `Rule::match_domain()` and `Rule::match_cidr()` with `.par_iter()`
+- **Rayon**: Parallel processing for rule/pattern matching via default global thread pool
+  - Used in `Rule` match methods and `Hosts::match_domain()` with `.par_iter()`
 
 ## Configuration
 
@@ -217,7 +216,7 @@ cdn.my-app.com.a.bdydns.com.  cdn.my-app.com  # CNAME
 
 ## Performance Considerations
 
-- **Release Profile**: Highly optimized (`opt-level = 3`, LTO, single codegen unit, strip symbols)
+- **Release Profile**: Highly optimized (`opt-level = 3`, fat LTO, single codegen unit, `panic = abort`, strip symbols)
 - **Caching**: Uses `moka` sync cache for DNS table lookups
 - **Parallel Matching**: Rule matching parallelized with Rayon
 - **Target Performance**: >120k QPS (as measured on AMD 5600G)
@@ -232,6 +231,6 @@ Gateway mode requires root/CAP_NET_ADMIN for TUN device creation.
 
 ## Important Notes
 
-- **Nightly Rust Required**: Do not remove `#![feature(test)]` or suggest stable alternatives
+- **Nightly Rust Required**: Do not remove `#![cfg_attr(test, feature(test))]` or suggest stable alternatives
 - **Static Routes Not Hot-Reloadable**: `type: route` rules require service restart
 - **GeoIP Not Implemented**: `dnsGeoIp` rule type is defined but not yet functional

--- a/src/config/dns_table.rs
+++ b/src/config/dns_table.rs
@@ -5,6 +5,7 @@ use hickory_server::proto::rr::{
 };
 use ipnet::IpNet;
 use moka::sync::Cache;
+use parking_lot::RwLock;
 use std::{
     fmt::{Display, Formatter},
     net::IpAddr,
@@ -15,7 +16,6 @@ use std::{
     },
     time::Duration,
 };
-use tokio::sync::RwLock;
 
 #[derive(Debug)]
 pub struct DnsTable {
@@ -70,9 +70,8 @@ impl DnsTable {
             .eviction_listener({
                 let mapping = Arc::clone(&mapping);
                 move |domain: Arc<String>, _addr: Arc<Addr>, _cause| {
-                    if let Ok(mut mapping_guard) = mapping.try_write() {
-                        mapping_guard.remove_by_left(&*domain);
-                    }
+                    let mut mapping_guard = mapping.write();
+                    mapping_guard.remove_by_left(&*domain);
                 }
             })
             .build();
@@ -94,7 +93,7 @@ impl DnsTable {
         let domain_owned = domain.to_string();
         self.cache.insert(domain_owned.clone(), addr.clone());
 
-        let mut mapping = self.mapping.write().await;
+        let mut mapping = self.mapping.write();
         mapping.insert(domain_owned, ip);
 
         addr
@@ -102,7 +101,7 @@ impl DnsTable {
 
     pub async fn find_by_ip(&self, ip: &IpAddr) -> Option<Arc<Addr>> {
         let domain = {
-            let mapping = self.mapping.read().await;
+            let mapping = self.mapping.read();
             mapping.get_by_right(ip).cloned()
         };
 
@@ -110,7 +109,7 @@ impl DnsTable {
             if let Some(addr) = self.cache.get(&domain) {
                 return Some(addr);
             }
-            let mut mapping = self.mapping.write().await;
+            let mut mapping = self.mapping.write();
             mapping.remove_by_right(ip);
         }
         None
@@ -122,12 +121,12 @@ impl DnsTable {
         }
 
         let has_mapping = {
-            let mapping = self.mapping.read().await;
+            let mapping = self.mapping.read();
             mapping.contains_left(domain)
         };
 
         if has_mapping {
-            let mut mapping = self.mapping.write().await;
+            let mut mapping = self.mapping.write();
             mapping.remove_by_left(domain);
         }
 
@@ -141,7 +140,7 @@ impl DnsTable {
         self.cache.insert(domain_owned.clone(), addr.clone());
 
         if let Some(ip_addr) = ip {
-            let mut mapping = self.mapping.write().await;
+            let mut mapping = self.mapping.write();
             mapping.insert(domain_owned, ip_addr);
         }
 
@@ -151,7 +150,7 @@ impl DnsTable {
     pub async fn clear(&self) {
         self.cache.invalidate_all();
 
-        let mut mapping = self.mapping.write().await;
+        let mut mapping = self.mapping.write();
         mapping.clear();
     }
 

--- a/src/config/setting.rs
+++ b/src/config/setting.rs
@@ -1,4 +1,6 @@
 use serde::Deserialize;
+use std::sync::OnceLock;
+use url::Url;
 
 #[derive(Debug, Deserialize)]
 #[serde(default)]
@@ -24,8 +26,44 @@ impl Default for Setting {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ParsedProxyUrl {
+    pub addr: String,
+    pub has_auth: bool,
+    pub username: String,
+    pub password: Option<String>,
+}
+
+impl ParsedProxyUrl {
+    pub fn parse(url: &str) -> Result<Self, url::ParseError> {
+        let url = Url::parse(url)?;
+        let host = url.host_str().unwrap_or("");
+        let port = url.port().unwrap_or(1080);
+        let username = url.username();
+        Ok(Self {
+            addr: format!("{host}:{port}"),
+            has_auth: !username.is_empty(),
+            username: username.to_string(),
+            password: url.password().map(|s| s.to_string()),
+        })
+    }
+}
+
 #[derive(Default, Debug, Deserialize)]
 pub struct Proxy {
     pub name: String,
     pub values: Vec<String>,
+    #[serde(skip)]
+    parsed: OnceLock<Vec<ParsedProxyUrl>>,
+}
+
+impl Proxy {
+    pub fn parsed_values(&self) -> &[ParsedProxyUrl] {
+        self.parsed.get_or_init(|| {
+            self.values
+                .iter()
+                .filter_map(|url| ParsedProxyUrl::parse(url).ok())
+                .collect()
+        })
+    }
 }

--- a/src/gateway/common.rs
+++ b/src/gateway/common.rs
@@ -1,21 +1,17 @@
 use super::nat::Session;
+use crate::config::setting::ParsedProxyUrl;
 use crate::runtime::ArcRuntime;
 use rand::prelude::*;
 use std::net::IpAddr;
 
-/// Randomly select a proxy URL from the list
-pub fn random_proxy(proxy: &[String]) -> String {
-    if proxy.len() == 1 {
-        return proxy[0].clone();
+pub fn random_proxy(proxies: &[ParsedProxyUrl]) -> &ParsedProxyUrl {
+    if proxies.len() == 1 {
+        return &proxies[0];
     }
     let mut rng = rand::rng();
-    proxy
-        .choose(&mut rng)
-        .cloned()
-        .unwrap_or_else(|| proxy[0].clone())
+    proxies.choose(&mut rng).unwrap_or(&proxies[0])
 }
 
-/// Find target proxy and address for a session
 pub async fn find_target(runtime: ArcRuntime, session: Session) -> Option<(String, String, u16)> {
     if let Some(addr) = runtime.dns_table.find_by_ip(&session.dst_addr.into()).await {
         return Some((addr.target.clone(), addr.domain.clone(), session.dst_port));

--- a/src/gateway/nat.rs
+++ b/src/gateway/nat.rs
@@ -1,4 +1,5 @@
 use bimap::BiMap;
+use parking_lot::RwLock;
 use std::{
     io::{Error, ErrorKind},
     net::Ipv4Addr,
@@ -8,7 +9,7 @@ use std::{
     },
     time::Duration,
 };
-use tokio::sync::{RwLock, mpsc::UnboundedSender};
+use tokio::sync::mpsc::UnboundedSender;
 
 use moka::future::Cache;
 
@@ -80,38 +81,30 @@ impl Nat {
         }
 
         let nat_port = {
-            let mut mapping = self.mapping.write().await;
+            let mut mapping = self.mapping.write();
 
             if let Some(&nat_port) = mapping.get_by_left(&addr_key) {
-                let session = Session {
-                    src_addr,
-                    dst_addr,
-                    src_port,
-                    dst_port,
-                    nat_port,
-                };
-                self.cache.insert(addr_key, session).await;
-                return Ok(session);
-            }
-
-            let mut assigned_port = 0;
-            for _ in 0..EPHEMERAL_PORT_RANGE {
-                let port = self.next_ephemeral_port();
-                if !mapping.contains_right(&port) {
-                    assigned_port = port;
-                    break;
+                nat_port
+            } else {
+                let mut assigned_port = 0;
+                for _ in 0..EPHEMERAL_PORT_RANGE {
+                    let port = self.next_ephemeral_port();
+                    if !mapping.contains_right(&port) {
+                        assigned_port = port;
+                        break;
+                    }
                 }
-            }
 
-            if assigned_port == 0 {
-                return Err(Error::new(
-                    ErrorKind::AddrInUse,
-                    "No available NAT port: ephemeral range exhausted",
-                ));
-            }
+                if assigned_port == 0 {
+                    return Err(Error::new(
+                        ErrorKind::AddrInUse,
+                        "No available NAT port: ephemeral range exhausted",
+                    ));
+                }
 
-            mapping.insert(addr_key, assigned_port);
-            assigned_port
+                mapping.insert(addr_key, assigned_port);
+                assigned_port
+            }
         };
 
         let session = Session {
@@ -128,7 +121,7 @@ impl Nat {
     }
 
     pub async fn find(&self, nat_port: u16) -> Option<Session> {
-        if let Some(addr_key) = self.get_addr_key_by_port_fast(&nat_port).await {
+        if let Some(addr_key) = self.get_addr_key_by_port_fast(&nat_port) {
             if let Some(session) = self.cache.get(&addr_key).await {
                 return Some(session);
             }
@@ -152,14 +145,14 @@ impl Nat {
         self.cache.invalidate_all();
 
         {
-            let mut mapping = self.mapping.write().await;
+            let mut mapping = self.mapping.write();
             mapping.clear();
         }
     }
 
     #[allow(dead_code)]
     pub async fn stats(&self) -> (usize, usize) {
-        let mapping_count = self.mapping.read().await.len();
+        let mapping_count = self.mapping.read().len();
         (mapping_count, self.cache.entry_count() as usize)
     }
 
@@ -172,21 +165,17 @@ impl Nat {
             .max_capacity(10000)
             .time_to_idle(ttl)
             .eviction_listener(move |addr_key: Arc<SessionKey>, session: Session, _cause| {
-                let mapping = mapping.clone();
-                let tx = tx.clone();
-                tokio::task::spawn(async move {
-                    let mut mapping_guard = mapping.write().await;
-                    let _ = mapping_guard.remove_by_left(&*addr_key);
-                    if let Some(ref tx) = tx {
-                        let _ = tx.send(session.nat_port);
-                    }
-                });
+                let mut mapping_guard = mapping.write();
+                let _ = mapping_guard.remove_by_left(&*addr_key);
+                if let Some(ref tx) = tx {
+                    let _ = tx.send(session.nat_port);
+                }
             })
             .build()
     }
 
-    async fn get_addr_key_by_port_fast(&self, nat_port: &u16) -> Option<SessionKey> {
-        let mapping = self.mapping.read().await;
+    fn get_addr_key_by_port_fast(&self, nat_port: &u16) -> Option<SessionKey> {
+        let mapping = self.mapping.read();
         mapping.get_by_right(nat_port).copied()
     }
 

--- a/src/gateway/proxy.rs
+++ b/src/gateway/proxy.rs
@@ -1,43 +1,34 @@
+use crate::config::setting::ParsedProxyUrl;
 use anyhow::{Error, anyhow};
 use fast_socks5::client::{Config, Socks5Stream};
 use std::time::Duration;
 use tokio::net::TcpStream;
-use url::Url;
 
-pub async fn open_proxy(proxy: String, target: &str, target_port: u16) -> Result<TcpStream, Error> {
-    let url = Url::parse(&proxy).unwrap();
-    let host = url.host().unwrap();
-    let port = url.port().map_or(80, |v| v);
-
-    let proxy = format!("{host}:{port}");
-
+pub async fn open_proxy(
+    proxy: &ParsedProxyUrl,
+    target: &str,
+    target_port: u16,
+) -> Result<TcpStream, Error> {
     let mut config = Config::default();
     config.set_connect_timeout(Duration::from_secs(5));
+    config.set_skip_auth(false);
 
     let target_addr = target.to_string();
 
-    let socket = if url.has_authority() {
-        config.set_skip_auth(false);
-
-        Socks5Stream::connect_with_password(
-            &proxy,
-            target_addr,
-            target_port,
-            url.username().to_string(),
-            url.password().map_or("default", |v| v).to_string(),
-            config,
-        )
-        .await
-    } else {
-        config.set_skip_auth(true);
-
-        Socks5Stream::connect(&proxy, target_addr, target_port, config).await
-    };
+    let socket = Socks5Stream::connect_with_password(
+        &proxy.addr,
+        target_addr,
+        target_port,
+        proxy.username.clone(),
+        proxy.password.as_deref().unwrap_or("default").to_string(),
+        config,
+    )
+    .await;
 
     socket.map(|v| v.get_socket()).map_err(|e| {
         anyhow!(
             "create proxy, proxy: {}, target: {}:{}, err: {}",
-            &proxy,
+            &proxy.addr,
             target,
             target_port,
             e

--- a/src/gateway/relay_tcp.rs
+++ b/src/gateway/relay_tcp.rs
@@ -98,7 +98,7 @@ async fn handle_connection(
     let outbound = timeout(
         PROXY_CONNECT_TIMEOUT,
         open_proxy(
-            common::random_proxy(&proxy_config.values),
+            common::random_proxy(proxy_config.parsed_values()),
             &target_addr,
             target_port,
         ),

--- a/src/gateway/relay_udp.rs
+++ b/src/gateway/relay_udp.rs
@@ -18,13 +18,13 @@ use tokio::{
     sync::{Mutex, Notify, mpsc::UnboundedReceiver},
     time::timeout,
 };
-use url::Url;
 
 use super::{common, nat::Session};
-use crate::{gateway::stats, runtime::ArcRuntime};
+use crate::{config::setting::ParsedProxyUrl, gateway::stats, runtime::ArcRuntime};
 
 const UDP_BUFFER_SIZE: usize = 4096;
 const UDP_ASSOCIATE_TIMEOUT: Duration = Duration::from_secs(5);
+const UDP_ASSOCIATION_MAX_CAPACITY: u64 = 10000;
 const UDP_ASSOCIATION_TTL: Duration = Duration::from_secs(300);
 const SOCKS5_UDP_HEADER_MIN: usize = 10;
 
@@ -53,19 +53,14 @@ struct UdpAssociation {
 }
 
 impl UdpAssociation {
-    async fn new(proxy_url: &str, nat_port: u16) -> Result<Self> {
-        let url = Url::parse(proxy_url)?;
-        let host = url.host().ok_or_else(|| anyhow!("missing host"))?;
-        let port = url.port().unwrap_or(1080);
+    async fn new(proxy: &ParsedProxyUrl, nat_port: u16) -> Result<Self> {
+        let mut tcp_control = TcpStream::connect(&proxy.addr).await?;
 
-        let proxy_addr = format!("{}:{}", host, port);
-        let mut tcp_control = TcpStream::connect(&proxy_addr).await?;
-
-        if url.username() != "" {
+        if proxy.has_auth {
             Self::perform_auth(
                 &mut tcp_control,
-                url.username(),
-                url.password().unwrap_or(""),
+                &proxy.username,
+                proxy.password.as_deref().unwrap_or(""),
             )
             .await?;
         } else {
@@ -320,10 +315,15 @@ pub(crate) struct UdpRelay {
 
 impl UdpRelay {
     pub fn new(runtime: ArcRuntime, mut rx: UnboundedReceiver<u16>) -> Self {
-        let associations: Cache<u16, Arc<UdpAssociation>> =
-            Cache::builder().time_to_idle(UDP_ASSOCIATION_TTL).build();
+        let associations: Cache<u16, Arc<UdpAssociation>> = Cache::builder()
+            .max_capacity(UDP_ASSOCIATION_MAX_CAPACITY)
+            .time_to_idle(UDP_ASSOCIATION_TTL)
+            .build();
 
         let invalidates = associations.clone();
+        // Cleanup path 1: NAT eviction signals via this channel.
+        // Cleanup path 2: recv loop idle timeout in get_or_create_association.
+        // Both paths are idempotent (deactivate + invalidate are safe to call twice).
         tokio::spawn(async move {
             while let Some(nat_port) = rx.recv().await {
                 if let Some(assoc) = invalidates.get(&nat_port) {
@@ -382,13 +382,9 @@ impl UdpRelay {
             .find(|p| p.name == proxy_name)
             .ok_or_else(|| anyhow!("Proxy not found: {}", proxy_name))?;
 
-        let proxy_url = common::random_proxy(&proxy_config.values);
+        let proxy = common::random_proxy(proxy_config.parsed_values());
 
-        let result = timeout(
-            UDP_ASSOCIATE_TIMEOUT,
-            UdpAssociation::new(&proxy_url, nat_port),
-        )
-        .await;
+        let result = timeout(UDP_ASSOCIATE_TIMEOUT, UdpAssociation::new(proxy, nat_port)).await;
 
         let assoc = match result {
             Ok(Ok(assoc)) => assoc,
@@ -412,7 +408,7 @@ impl UdpRelay {
         let target_host = target_host.to_string();
         let associations_cache = self.associations.clone();
         tokio::spawn(async move {
-            while let Ok(Some(data)) = assoc_clone.recv().await {
+            while let Ok(Ok(Some(data))) = timeout(UDP_ASSOCIATION_TTL, assoc_clone.recv()).await {
                 if let Ok((_src_addr, _src_port, data)) = UdpAssociation::decode_socks5_udp(&data) {
                     let down = data.len() as u64;
                     callback(data).await;
@@ -426,6 +422,7 @@ impl UdpRelay {
                     );
                 }
             }
+            assoc_clone.deactivate();
             log::debug!(
                 "UDP receive loop ended for proxy {} (nat_port: {}), invalidating association",
                 proxy_name,

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -213,8 +213,8 @@ impl Gateway {
         let src = v4.get_source();
         let dst = v4.get_destination();
 
-        let mut payload_vec = v4.payload().to_vec();
-        let mut packet = MutableIcmpPacket::new(&mut payload_vec).unwrap();
+        let mut payload = v4.payload().to_vec();
+        let mut packet = MutableIcmpPacket::new(&mut payload).unwrap();
         let icmp_type = packet.get_icmp_type();
 
         // Handle ICMP packet
@@ -227,9 +227,9 @@ impl Gateway {
                 packet.set_checksum(icmp::checksum(&packet.to_immutable()));
 
                 v4.set_destination(src);
-                v4.set_source(dst); // Respond as if we are the target
+                v4.set_source(dst);
                 v4.set_ttl(64);
-                v4.set_payload(&payload_vec);
+                v4.set_payload(&payload);
                 v4.set_checksum(ipv4::checksum(&v4.to_immutable()));
 
                 let _ = packet_tx.send(Bytes::copy_from_slice(v4.packet()));

--- a/src/gateway/stats.rs
+++ b/src/gateway/stats.rs
@@ -70,12 +70,14 @@ pub fn update_metrics(
         .with_label_values(&[protocol_str, "download", proxy])
         .inc_by(down);
 
-    RELAY_HOST_COUNT
-        .with_label_values(&[protocol_str, "upload", domain])
-        .inc_by(up);
-    RELAY_HOST_COUNT
-        .with_label_values(&[protocol_str, "download", domain])
-        .inc_by(down);
-
     RELAY_COUNT_CACHE.insert(domain.to_string(), 0);
+
+    if RELAY_COUNT_CACHE.get(domain).is_some() {
+        RELAY_HOST_COUNT
+            .with_label_values(&[protocol_str, "upload", domain])
+            .inc_by(up);
+        RELAY_HOST_COUNT
+            .with_label_values(&[protocol_str, "download", domain])
+            .inc_by(down);
+    }
 }

--- a/src/rule/matcher.rs
+++ b/src/rule/matcher.rs
@@ -72,15 +72,14 @@ impl RuleMatcher {
     pub fn match_domain(&self, domain: &str) -> Option<Cow<'_, str>> {
         self.patterns
             .iter()
-            .find(|&v| v.matches(domain))
-            .map(|p| Cow::Owned(p.as_str().to_string()))
+            .position(|v| v.matches(domain))
+            .map(|i| Cow::Borrowed(self.values[i].as_str()))
     }
 
-    /// Match IP address against CIDR ranges (sequential search)
     pub fn match_cidr(&self, ip: &IpAddr) -> Option<Cow<'_, str>> {
         self.cidrs
             .iter()
-            .find(|&v| v.contains(ip))
-            .map(|cidr| Cow::Owned(cidr.to_string()))
+            .position(|v| v.contains(ip))
+            .map(|i| Cow::Borrowed(self.values[i].as_str()))
     }
 }


### PR DESCRIPTION
Reduces per-request allocations in DNS lookups, gateway NAT/proxy handling, and rule matching.

- Replace async RwLock with parking_lot RwLock where guards don't span `.await`
- Pre-parse proxy URLs once instead of on every connection
- Return borrowed references in rule matching instead of allocating new strings
- Add idle timeout and capacity cap to UDP association cache
- Fix host-level metrics dedup in stats
