### PR TITLE
perf(gateway): optimize TUN throughput and NAT concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +754,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1243,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags",
  "libc",
@@ -1261,6 +1281,7 @@ dependencies = [
  "bimap",
  "bytes",
  "clap",
+ "dashmap",
  "env_logger",
  "fast-socks5",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1"
 bimap = "0.6"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
+dashmap = "6.1.0"
 env_logger = "0.11"
 fast-socks5 = "1"
 futures = "0.3"

--- a/src/gateway/nat.rs
+++ b/src/gateway/nat.rs
@@ -1,17 +1,15 @@
-use bimap::BiMap;
-use parking_lot::RwLock;
+use dashmap::DashMap;
+use moka::future::Cache;
 use std::{
     io::{Error, ErrorKind},
     net::Ipv4Addr,
     sync::{
         Arc,
-        atomic::{AtomicU16, Ordering},
+        atomic::{AtomicU16, AtomicU64, Ordering},
     },
     time::Duration,
 };
 use tokio::sync::mpsc::UnboundedSender;
-
-use moka::future::Cache;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SessionKey {
@@ -24,10 +22,13 @@ pub struct SessionKey {
 const EPHEMERAL_PORT_START: u16 = 1024;
 const EPHEMERAL_PORT_END: u16 = 65535;
 const EPHEMERAL_PORT_RANGE: u16 = EPHEMERAL_PORT_END - EPHEMERAL_PORT_START + 1;
+const BITMAP_WORDS: usize = (EPHEMERAL_PORT_RANGE as usize + 63) / 64;
 
 pub struct Nat {
     cache: Cache<SessionKey, Session>,
-    mapping: Arc<RwLock<BiMap<SessionKey, u16>>>,
+    key_to_session: DashMap<SessionKey, Session>,
+    port_to_key: DashMap<u16, SessionKey>,
+    bitmap: Arc<[AtomicU64; BITMAP_WORDS]>,
     port_counter: AtomicU16,
 }
 
@@ -52,12 +53,19 @@ impl Nat {
             Type::Udp => Duration::from_secs(60),
         };
 
-        let mapping = Arc::new(RwLock::new(BiMap::new()));
-        let cache = Self::new_cache(ttl, mapping.clone(), tx);
+        let bitmap = {
+            let arr: [AtomicU64; BITMAP_WORDS] = std::array::from_fn(|_| AtomicU64::new(0));
+            Arc::new(arr)
+        };
+        let key_to_session = DashMap::new();
+        let port_to_key = DashMap::new();
+        let cache = Self::new_cache(ttl, key_to_session.clone(), port_to_key.clone(), bitmap.clone(), tx);
 
         Self {
             cache,
-            mapping,
+            key_to_session,
+            port_to_key,
+            bitmap,
             port_counter: AtomicU16::new(0),
         }
     }
@@ -69,125 +77,132 @@ impl Nat {
         dst_addr: Ipv4Addr,
         dst_port: u16,
     ) -> Result<Session, Error> {
-        let addr_key = SessionKey {
+        let key = SessionKey {
             src_addr,
             dst_addr,
             src_port,
             dst_port,
         };
 
-        if let Some(session) = self.cache.get(&addr_key).await {
+        if let Some(session) = self.cache.get(&key).await {
             return Ok(session);
         }
 
-        let nat_port = {
-            let mut mapping = self.mapping.write();
-
-            if let Some(&nat_port) = mapping.get_by_left(&addr_key) {
-                nat_port
-            } else {
-                let mut assigned_port = 0;
-                for _ in 0..EPHEMERAL_PORT_RANGE {
-                    let port = self.next_ephemeral_port();
-                    if !mapping.contains_right(&port) {
-                        assigned_port = port;
-                        break;
-                    }
-                }
-
-                if assigned_port == 0 {
-                    return Err(Error::new(
-                        ErrorKind::AddrInUse,
-                        "No available NAT port: ephemeral range exhausted",
-                    ));
-                }
-
-                mapping.insert(addr_key, assigned_port);
-                assigned_port
+        let session = match self.key_to_session.entry(key) {
+            dashmap::mapref::entry::Entry::Occupied(entry) => *entry.get(),
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let nat_port = self.allocate_port()?;
+                let session = Session {
+                    src_addr,
+                    dst_addr,
+                    src_port,
+                    dst_port,
+                    nat_port,
+                };
+                self.port_to_key.insert(nat_port, key);
+                entry.insert(session);
+                session
             }
         };
 
-        let session = Session {
-            src_addr,
-            dst_addr,
-            src_port,
-            dst_port,
-            nat_port,
-        };
-
-        self.cache.insert(addr_key, session).await;
-
+        self.cache.insert(key, session).await;
         Ok(session)
     }
 
     pub async fn find(&self, nat_port: u16) -> Option<Session> {
-        if let Some(addr_key) = self.get_addr_key_by_port_fast(&nat_port) {
-            if let Some(session) = self.cache.get(&addr_key).await {
-                return Some(session);
-            }
+        let addr_key = match self.port_to_key.get(&nat_port) {
+            Some(k) => *k.value(),
+            None => return None,
+        };
 
-            let session = Session {
-                src_addr: addr_key.src_addr,
-                dst_addr: addr_key.dst_addr,
-                src_port: addr_key.src_port,
-                dst_port: addr_key.dst_port,
-                nat_port,
-            };
+        if let Some(session) = self.cache.get(&addr_key).await {
+            return Some(session);
+        }
+
+        if let Some(session) = self.key_to_session.get(&addr_key) {
+            let session = *session.value();
             self.cache.insert(addr_key, session).await;
             return Some(session);
         }
 
-        None
+        let session = Session {
+            src_addr: addr_key.src_addr,
+            dst_addr: addr_key.dst_addr,
+            src_port: addr_key.src_port,
+            dst_port: addr_key.dst_port,
+            nat_port,
+        };
+        self.cache.insert(addr_key, session).await;
+        Some(session)
     }
 
     #[allow(dead_code)]
     pub async fn clear(&self) {
         self.cache.invalidate_all();
 
-        {
-            let mut mapping = self.mapping.write();
-            mapping.clear();
+        self.key_to_session.clear();
+        self.port_to_key.clear();
+
+        for word in self.bitmap.iter() {
+            word.store(0, Ordering::Release);
         }
     }
 
     #[allow(dead_code)]
     pub async fn stats(&self) -> (usize, usize) {
-        let mapping_count = self.mapping.read().len();
-        (mapping_count, self.cache.entry_count() as usize)
+        (self.key_to_session.len(), self.cache.entry_count() as usize)
+    }
+
+    fn allocate_port(&self) -> Result<u16, Error> {
+        for _ in 0..EPHEMERAL_PORT_RANGE {
+            let offset = self.port_counter.fetch_add(1, Ordering::Relaxed) % EPHEMERAL_PORT_RANGE;
+            let word = offset as usize / 64;
+            let bit = offset as usize % 64;
+            let mask = 1u64 << bit;
+            let old = self.bitmap[word].fetch_or(mask, Ordering::AcqRel);
+            if old & mask == 0 {
+                return Ok(EPHEMERAL_PORT_START + offset);
+            }
+        }
+        Err(Error::new(
+            ErrorKind::AddrInUse,
+            "No available NAT port: ephemeral range exhausted",
+        ))
     }
 
     fn new_cache(
         ttl: Duration,
-        mapping: Arc<RwLock<BiMap<SessionKey, u16>>>,
+        key_to_session: DashMap<SessionKey, Session>,
+        port_to_key: DashMap<u16, SessionKey>,
+        bitmap: Arc<[AtomicU64; BITMAP_WORDS]>,
         tx: Option<UnboundedSender<u16>>,
     ) -> Cache<SessionKey, Session> {
         Cache::builder()
             .max_capacity(10000)
             .time_to_idle(ttl)
-            .eviction_listener(move |addr_key: Arc<SessionKey>, session: Session, _cause| {
-                let mut mapping_guard = mapping.write();
-                let _ = mapping_guard.remove_by_left(&*addr_key);
-                if let Some(ref tx) = tx {
-                    let _ = tx.send(session.nat_port);
+            .eviction_listener(move |key: Arc<SessionKey>, session: Session, _cause| {
+                if key_to_session
+                    .remove_if(&*key, |_, v| v.nat_port == session.nat_port)
+                    .is_some()
+                {
+                    port_to_key.remove(&session.nat_port);
+                    let offset = session.nat_port - EPHEMERAL_PORT_START;
+                    let word = offset as usize / 64;
+                    let bit = offset as usize % 64;
+                    bitmap[word].fetch_and(!(1u64 << bit), Ordering::Release);
+                    if let Some(ref tx) = tx {
+                        let _ = tx.send(session.nat_port);
+                    }
                 }
             })
             .build()
-    }
-
-    fn get_addr_key_by_port_fast(&self, nat_port: &u16) -> Option<SessionKey> {
-        let mapping = self.mapping.read();
-        mapping.get_by_right(nat_port).copied()
-    }
-
-    fn next_ephemeral_port(&self) -> u16 {
-        let offset = self.port_counter.fetch_add(1, Ordering::Relaxed) % EPHEMERAL_PORT_RANGE;
-        EPHEMERAL_PORT_START + offset
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[tokio::test]
     async fn it_works() {
@@ -219,5 +234,28 @@ mod tests {
             .await
             .unwrap();
         assert_ne!(session.nat_port, 0);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_port_allocation() {
+        let nat = Arc::new(Nat::new(Type::Tcp, None));
+        let mut handles = vec![];
+        for i in 0..100u16 {
+            let nat = nat.clone();
+            handles.push(tokio::spawn(async move {
+                nat.create(
+                    Ipv4Addr::new(10, 0, 0, 1),
+                    10000 + i,
+                    Ipv4Addr::new(93, 184, 216, 34),
+                    80,
+                )
+                .await
+                .unwrap()
+            }));
+        }
+        let results = futures::future::join_all(handles).await;
+        let sessions: Vec<Session> = results.into_iter().map(|h| h.unwrap()).collect();
+        let nat_ports: HashSet<u16> = sessions.iter().map(|s| s.nat_port).collect();
+        assert_eq!(nat_ports.len(), 100, "all NAT ports should be unique");
     }
 }

--- a/src/gateway/nat.rs
+++ b/src/gateway/nat.rs
@@ -22,7 +22,7 @@ pub struct SessionKey {
 const EPHEMERAL_PORT_START: u16 = 1024;
 const EPHEMERAL_PORT_END: u16 = 65535;
 const EPHEMERAL_PORT_RANGE: u16 = EPHEMERAL_PORT_END - EPHEMERAL_PORT_START + 1;
-const BITMAP_WORDS: usize = (EPHEMERAL_PORT_RANGE as usize + 63) / 64;
+const BITMAP_WORDS: usize = (EPHEMERAL_PORT_RANGE as usize).div_ceil(64);
 
 pub struct Nat {
     cache: Cache<SessionKey, Session>,

--- a/src/gateway/nat.rs
+++ b/src/gateway/nat.rs
@@ -9,7 +9,7 @@ use std::{
     },
     time::Duration,
 };
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SessionKey {
@@ -47,7 +47,7 @@ pub struct Session {
 }
 
 impl Nat {
-    pub fn new(nat_type: Type, tx: Option<UnboundedSender<u16>>) -> Self {
+    pub fn new(nat_type: Type, tx: Option<Sender<u16>>) -> Self {
         let ttl = match nat_type {
             Type::Tcp => Duration::from_secs(300),
             Type::Udp => Duration::from_secs(60),
@@ -175,7 +175,7 @@ impl Nat {
         key_to_session: DashMap<SessionKey, Session>,
         port_to_key: DashMap<u16, SessionKey>,
         bitmap: Arc<[AtomicU64; BITMAP_WORDS]>,
-        tx: Option<UnboundedSender<u16>>,
+        tx: Option<Sender<u16>>,
     ) -> Cache<SessionKey, Session> {
         Cache::builder()
             .max_capacity(10000)
@@ -191,7 +191,7 @@ impl Nat {
                     let bit = offset as usize % 64;
                     bitmap[word].fetch_and(!(1u64 << bit), Ordering::Release);
                     if let Some(ref tx) = tx {
-                        let _ = tx.send(session.nat_port);
+                        let _ = tx.try_send(session.nat_port);
                     }
                 }
             })

--- a/src/gateway/relay_udp.rs
+++ b/src/gateway/relay_udp.rs
@@ -15,7 +15,7 @@ use moka::sync::Cache;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpStream, UdpSocket},
-    sync::{Mutex, Notify, mpsc::UnboundedReceiver},
+    sync::{Mutex, Notify, mpsc::Receiver},
     time::timeout,
 };
 
@@ -314,7 +314,7 @@ pub(crate) struct UdpRelay {
 }
 
 impl UdpRelay {
-    pub fn new(runtime: ArcRuntime, mut rx: UnboundedReceiver<u16>) -> Self {
+    pub fn new(runtime: ArcRuntime, mut rx: Receiver<u16>) -> Self {
         let associations: Cache<u16, Arc<UdpAssociation>> = Cache::builder()
             .max_capacity(UDP_ASSOCIATION_MAX_CAPACITY)
             .time_to_idle(UDP_ASSOCIATION_TTL)

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use tokio::{
     join,
-    sync::mpsc::{self, UnboundedSender},
+    sync::mpsc::{self, Sender},
 };
 use tun_rs::{AsyncDevice, DeviceBuilder};
 
@@ -62,7 +62,7 @@ impl Gateway {
             .expect("Failed to get local address")
             .port();
 
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1024);
         let tcp_nat = Arc::new(Nat::new(Type::Tcp, None));
         let udp_nat = Arc::new(Nat::new(Type::Udp, Some(tx)));
         let udp_relay = UdpRelay::new(runtime.clone(), rx);
@@ -82,7 +82,7 @@ impl Gateway {
 
     async fn serve(&self) {
         let dev = Arc::new(self.setup().await);
-        let (packet_tx, mut packet_rx) = mpsc::unbounded_channel::<Bytes>();
+        let (packet_tx, mut packet_rx) = mpsc::channel::<Bytes>(4096);
 
         let write_task = async {
             let dev = dev.clone();
@@ -113,7 +113,7 @@ impl Gateway {
     }
 
     #[cfg(target_os = "linux")]
-    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: UnboundedSender<Bytes>) {
+    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: Sender<Bytes>) {
         let mut original_buffer = vec![0u8; VIRTIO_NET_HDR_LEN + 65535];
         let mut bufs = vec![vec![0u8; 1500]; IDEAL_BATCH_SIZE];
         let mut sizes = vec![0usize; IDEAL_BATCH_SIZE];
@@ -161,7 +161,7 @@ impl Gateway {
     }
 
     #[cfg(not(target_os = "linux"))]
-    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: UnboundedSender<Bytes>) {
+    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: Sender<Bytes>) {
         let mut buf = BytesMut::zeroed(65536);
         while let Ok(len) = dev.recv(&mut buf).await {
             let mut ipv4 = match MutableIpv4Packet::new(&mut buf[..len]) {
@@ -280,7 +280,7 @@ impl Gateway {
 
     async fn handle_icmp_v4(
         &self,
-        packet_tx: UnboundedSender<Bytes>,
+        packet_tx: Sender<Bytes>,
         v4: &mut MutableIpv4Packet<'_>,
     ) {
         let src = v4.get_source();
@@ -305,7 +305,7 @@ impl Gateway {
                 v4.set_payload(&payload);
                 v4.set_checksum(ipv4::checksum(&v4.to_immutable()));
 
-                let _ = packet_tx.send(Bytes::copy_from_slice(v4.packet()));
+                let _ = packet_tx.try_send(Bytes::copy_from_slice(v4.packet()));
             }
             _ => {
                 debug!("Ignoring ICMP type: {:?}", icmp_type);
@@ -315,7 +315,7 @@ impl Gateway {
 
     async fn handle_udp_v4(
         &self,
-        packet_tx: UnboundedSender<Bytes>,
+        packet_tx: Sender<Bytes>,
         v4: &mut MutableIpv4Packet<'_>,
     ) -> Result<(), Error> {
         let mut payload = v4.payload().to_vec();
@@ -359,7 +359,7 @@ impl Gateway {
             p.set_payload(payload);
             p.set_checksum(ipv4::checksum(&p.to_immutable()));
 
-            let _ = packet_tx.send(Bytes::copy_from_slice(p.packet()));
+            let _ = packet_tx.try_send(Bytes::copy_from_slice(p.packet()));
         }
 
         let session = self.udp_nat.create(src, src_port, dst, dst_port).await?;
@@ -406,7 +406,7 @@ impl Gateway {
                 ip_packet.set_payload(udp_packet.packet());
                 ip_packet.set_checksum(ipv4::checksum(&ip_packet.to_immutable()));
 
-                let _ = packet_tx.send(Bytes::copy_from_slice(ip_packet.packet()));
+                let _ = packet_tx.try_send(Bytes::copy_from_slice(ip_packet.packet()));
             }
         };
 
@@ -416,7 +416,7 @@ impl Gateway {
 
     async fn handle_tcp_v4(
         &self,
-        packet_tx: UnboundedSender<Bytes>,
+        packet_tx: Sender<Bytes>,
         v4: &mut MutableIpv4Packet<'_>,
     ) -> Result<(), Error> {
         let mut payload = v4.payload().to_vec();
@@ -462,7 +462,7 @@ impl Gateway {
         v4.set_payload(packet.packet());
         v4.set_checksum(ipv4::checksum(&v4.to_immutable()));
 
-        let _ = packet_tx.send(Bytes::copy_from_slice(v4.packet()));
+        let _ = packet_tx.try_send(Bytes::copy_from_slice(v4.packet()));
         Ok(())
     }
 }

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -82,7 +82,7 @@ impl Gateway {
 
     async fn serve(&self) {
         let dev = Arc::new(self.setup().await);
-        let (packet_tx, mut packet_rx) = mpsc::channel::<Bytes>(4096);
+        let (packet_tx, mut packet_rx) = mpsc::channel::<BytesMut>(4096);
 
         let write_task = async {
             let dev = dev.clone();
@@ -100,7 +100,7 @@ impl Gateway {
     }
 
     #[cfg(target_os = "linux")]
-    async fn send_packet(&self, dev: &AsyncDevice, packet: &[u8]) {
+    async fn send_packet(&self, dev: &AsyncDevice, packet: &BytesMut) {
         let mut out = BytesMut::with_capacity(VIRTIO_NET_HDR_LEN + packet.len());
         out.extend_from_slice(&[0u8; VIRTIO_NET_HDR_LEN]);
         out.extend_from_slice(packet);
@@ -108,12 +108,12 @@ impl Gateway {
     }
 
     #[cfg(not(target_os = "linux"))]
-    async fn send_packet(&self, dev: &AsyncDevice, packet: &[u8]) {
+    async fn send_packet(&self, dev: &AsyncDevice, packet: &BytesMut) {
         let _ = dev.send(packet).await;
     }
 
     #[cfg(target_os = "linux")]
-    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: Sender<Bytes>) {
+    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: Sender<BytesMut>) {
         let mut original_buffer = vec![0u8; VIRTIO_NET_HDR_LEN + 65535];
         let mut bufs = vec![vec![0u8; 1500]; IDEAL_BATCH_SIZE];
         let mut sizes = vec![0usize; IDEAL_BATCH_SIZE];
@@ -161,7 +161,7 @@ impl Gateway {
     }
 
     #[cfg(not(target_os = "linux"))]
-    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: Sender<Bytes>) {
+    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: Sender<BytesMut>) {
         let mut buf = BytesMut::zeroed(65536);
         while let Ok(len) = dev.recv(&mut buf).await {
             let mut ipv4 = match MutableIpv4Packet::new(&mut buf[..len]) {
@@ -280,7 +280,7 @@ impl Gateway {
 
     async fn handle_icmp_v4(
         &self,
-        packet_tx: Sender<Bytes>,
+        packet_tx: Sender<BytesMut>,
         v4: &mut MutableIpv4Packet<'_>,
     ) {
         let src = v4.get_source();
@@ -305,7 +305,7 @@ impl Gateway {
                 v4.set_payload(&payload);
                 v4.set_checksum(ipv4::checksum(&v4.to_immutable()));
 
-                let _ = packet_tx.try_send(Bytes::copy_from_slice(v4.packet()));
+                let _ = packet_tx.try_send(BytesMut::from(v4.packet()));
             }
             _ => {
                 debug!("Ignoring ICMP type: {:?}", icmp_type);
@@ -315,7 +315,7 @@ impl Gateway {
 
     async fn handle_udp_v4(
         &self,
-        packet_tx: Sender<Bytes>,
+        packet_tx: Sender<BytesMut>,
         v4: &mut MutableIpv4Packet<'_>,
     ) -> Result<(), Error> {
         let mut payload = v4.payload().to_vec();
@@ -359,7 +359,7 @@ impl Gateway {
             p.set_payload(payload);
             p.set_checksum(ipv4::checksum(&p.to_immutable()));
 
-            let _ = packet_tx.try_send(Bytes::copy_from_slice(p.packet()));
+            let _ = packet_tx.try_send(buf);
         }
 
         let session = self.udp_nat.create(src, src_port, dst, dst_port).await?;
@@ -406,7 +406,7 @@ impl Gateway {
                 ip_packet.set_payload(udp_packet.packet());
                 ip_packet.set_checksum(ipv4::checksum(&ip_packet.to_immutable()));
 
-                let _ = packet_tx.try_send(Bytes::copy_from_slice(ip_packet.packet()));
+                let _ = packet_tx.try_send(ip_buf);
             }
         };
 
@@ -416,7 +416,7 @@ impl Gateway {
 
     async fn handle_tcp_v4(
         &self,
-        packet_tx: Sender<Bytes>,
+        packet_tx: Sender<BytesMut>,
         v4: &mut MutableIpv4Packet<'_>,
     ) -> Result<(), Error> {
         let mut payload = v4.payload().to_vec();
@@ -462,7 +462,7 @@ impl Gateway {
         v4.set_payload(packet.packet());
         v4.set_checksum(ipv4::checksum(&v4.to_immutable()));
 
-        let _ = packet_tx.try_send(Bytes::copy_from_slice(v4.packet()));
+        let _ = packet_tx.try_send(BytesMut::from(v4.packet()));
         Ok(())
     }
 }

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -24,6 +24,9 @@ use tokio::{
 };
 use tun_rs::{AsyncDevice, DeviceBuilder};
 
+#[cfg(target_os = "linux")]
+use tun_rs::{IDEAL_BATCH_SIZE, VIRTIO_NET_HDR_LEN};
+
 use super::{
     nat::{Nat, Type},
     relay_udp::UdpRelay,
@@ -84,37 +87,105 @@ impl Gateway {
         let write_task = async {
             let dev = dev.clone();
             while let Some(packet) = packet_rx.recv().await {
-                let _ = dev.send(&packet).await;
+                self.send_packet(&dev, &packet).await;
             }
         };
 
         let handle_task = async {
             let dev = dev.clone();
-            let mut buf = BytesMut::zeroed(65536);
-            while let Ok(len) = dev.recv(&mut buf).await {
-                let packet_tx = packet_tx.clone();
-                let mut ipv4 = ipv4::MutableIpv4Packet::new(&mut buf[..len]).unwrap();
-                let protocol = ipv4.get_next_level_protocol();
-                let handle_result = match protocol {
-                    IpNextHeaderProtocols::Icmp => {
-                        self.handle_icmp_v4(packet_tx.clone(), &mut ipv4).await;
-                        Ok(())
-                    }
-                    IpNextHeaderProtocols::Udp => {
-                        self.handle_udp_v4(packet_tx.clone(), &mut ipv4).await
-                    }
-                    IpNextHeaderProtocols::Tcp => {
-                        self.handle_tcp_v4(packet_tx.clone(), &mut ipv4).await
-                    }
-                    _ => Ok(()),
-                };
-                if let Err(e) = handle_result {
-                    error!("Failed to handle packet: {}", e);
-                }
-            }
+            self.run_packet_loop(dev, packet_tx.clone()).await;
         };
 
         join!(write_task, handle_task);
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn send_packet(&self, dev: &AsyncDevice, packet: &[u8]) {
+        let mut out = BytesMut::with_capacity(VIRTIO_NET_HDR_LEN + packet.len());
+        out.extend_from_slice(&[0u8; VIRTIO_NET_HDR_LEN]);
+        out.extend_from_slice(packet);
+        let _ = dev.send(&out).await;
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn send_packet(&self, dev: &AsyncDevice, packet: &[u8]) {
+        let _ = dev.send(packet).await;
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: UnboundedSender<Bytes>) {
+        let mut original_buffer = vec![0u8; VIRTIO_NET_HDR_LEN + 65535];
+        let mut bufs = vec![vec![0u8; 1500]; IDEAL_BATCH_SIZE];
+        let mut sizes = vec![0usize; IDEAL_BATCH_SIZE];
+
+        loop {
+            match dev
+                .recv_multiple(&mut original_buffer, &mut bufs, &mut sizes, 0)
+                .await
+            {
+                Ok(count) => {
+                    for i in 0..count {
+                        let len = sizes[i];
+                        if len == 0 {
+                            continue;
+                        }
+                        let mut ipv4 = match MutableIpv4Packet::new(&mut bufs[i][..len]) {
+                            Some(p) => p,
+                            None => continue,
+                        };
+                        let protocol = ipv4.get_next_level_protocol();
+                        let handle_result = match protocol {
+                            IpNextHeaderProtocols::Icmp => {
+                                self.handle_icmp_v4(packet_tx.clone(), &mut ipv4)
+                                    .await;
+                                Ok(())
+                            }
+                            IpNextHeaderProtocols::Udp => {
+                                self.handle_udp_v4(packet_tx.clone(), &mut ipv4).await
+                            }
+                            IpNextHeaderProtocols::Tcp => {
+                                self.handle_tcp_v4(packet_tx.clone(), &mut ipv4).await
+                            }
+                            _ => Ok(()),
+                        };
+                        if let Err(e) = handle_result {
+                            error!("Failed to handle packet: {}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("recv_multiple error: {}", e);
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn run_packet_loop(&self, dev: Arc<AsyncDevice>, packet_tx: UnboundedSender<Bytes>) {
+        let mut buf = BytesMut::zeroed(65536);
+        while let Ok(len) = dev.recv(&mut buf).await {
+            let mut ipv4 = match MutableIpv4Packet::new(&mut buf[..len]) {
+                Some(p) => p,
+                None => continue,
+            };
+            let protocol = ipv4.get_next_level_protocol();
+            let handle_result = match protocol {
+                IpNextHeaderProtocols::Icmp => {
+                    self.handle_icmp_v4(packet_tx.clone(), &mut ipv4).await;
+                    Ok(())
+                }
+                IpNextHeaderProtocols::Udp => {
+                    self.handle_udp_v4(packet_tx.clone(), &mut ipv4).await
+                }
+                IpNextHeaderProtocols::Tcp => {
+                    self.handle_tcp_v4(packet_tx.clone(), &mut ipv4).await
+                }
+                _ => Ok(()),
+            };
+            if let Err(e) = handle_result {
+                error!("Failed to handle packet: {}", e);
+            }
+        }
     }
 
     async fn setup(&self) -> AsyncDevice {
@@ -132,6 +203,8 @@ impl Gateway {
         {
             builder = builder.name("kf0");
             builder = builder.tx_queue_len(1000);
+            builder = builder.offload(true);
+            builder = builder.multi_queue(true);
         }
 
         let dev = match builder.build_async() {


### PR DESCRIPTION
## Summary

Optimize gateway performance by leveraging tun-rs hardware offload capabilities, eliminating NAT allocation lock contention, and adding backpressure control.

## Changes

- **Enable TSO/GSO offload and batch packet processing on Linux** — use `recv_multiple` for VirtioNetHdr-aware batch reads, with non-Linux fallback preserved
- **Replace NAT port allocation with lock-free bitmap** — eliminates `RwLock<BiMap>` global write lock; O(1) atomic allocation via `fetch_or`
- **Add backpressure with bounded channels** — cap TUN write and NAT eviction channels; tail-drop under overload
- **Reduce per-packet allocations** — use `BytesMut` throughout the packet pipeline